### PR TITLE
Allow renaming of binaries

### DIFF
--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/marwanhawari/stew/constants"
 	stew "github.com/marwanhawari/stew/lib"
@@ -57,7 +57,7 @@ func Browse(cliInput string) {
 	assetIndex, _ := stew.Contains(releaseAssets, asset)
 
 	downloadURL := githubProject.Releases[tagIndex].Assets[assetIndex].DownloadURL
-	downloadPath := path.Join(stewPkgPath, asset)
+	downloadPath := filepath.Join(stewPkgPath, asset)
 	downloadPathExists, err := stew.PathExists(downloadPath)
 	stew.CatchAndExit(err)
 

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/marwanhawari/stew/constants"
@@ -102,7 +102,7 @@ func Install(cliInputs []string) {
 			fmt.Println(constants.GreenColor(asset))
 		}
 
-		downloadPath := path.Join(stewPkgPath, asset)
+		downloadPath := filepath.Join(stewPkgPath, asset)
 		downloadPathExists, err := stew.PathExists(downloadPath)
 		stew.CatchAndExit(err)
 		if downloadPathExists {

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/marwanhawari/stew/constants"
+	stew "github.com/marwanhawari/stew/lib"
+)
+
+// Rename is executed when you run `stew rename`
+func Rename(cliInput string) {
+
+	err := stew.ValidateCLIInput(cliInput)
+	stew.CatchAndExit(err)
+
+	stewPath, err := stew.GetStewPath()
+	stew.CatchAndExit(err)
+	systemInfo := stew.NewSystemInfo(stewPath)
+
+	userOS := systemInfo.Os
+	userArch := systemInfo.Arch
+	stewBinPath := systemInfo.StewBinPath
+	stewLockFilePath := systemInfo.StewLockFilePath
+
+	lockFile, err := stew.NewLockFile(stewLockFilePath, userOS, userArch)
+	stew.CatchAndExit(err)
+
+	if len(lockFile.Packages) == 0 {
+		stew.CatchAndExit(stew.NoBinariesInstalledError{})
+	}
+
+	var binaryFound bool
+	var renamedBinaryName string
+	for index, pkg := range lockFile.Packages {
+		if pkg.Binary == cliInput {
+			renamedBinaryName, err = stew.PromptRenameBinary(cliInput)
+			stew.CatchAndExit(err)
+			err = os.Rename(filepath.Join(stewBinPath, cliInput), filepath.Join(stewBinPath, renamedBinaryName))
+			stew.CatchAndExit(err)
+
+			lockFile.Packages[index].Binary = renamedBinaryName
+			binaryFound = true
+			break
+		}
+	}
+	if !binaryFound {
+		stew.CatchAndExit(stew.BinaryNotInstalledError{Binary: cliInput})
+	}
+
+	err = stew.WriteLockFileJSON(lockFile, stewLockFilePath)
+	stew.CatchAndExit(err)
+
+	fmt.Printf("✨ Successfully renamed the %v binary to %v\n", constants.GreenColor(cliInput), constants.GreenColor(renamedBinaryName))
+}

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/marwanhawari/stew/constants"
 	stew "github.com/marwanhawari/stew/lib"
@@ -89,7 +89,7 @@ func Upgrade(cliFlag bool, binaryName string) {
 
 			downloadURL := githubProject.Releases[tagIndex].Assets[assetIndex].DownloadURL
 
-			downloadPath := path.Join(stewPkgPath, asset)
+			downloadPath := filepath.Join(stewPkgPath, asset)
 			downloadPathExists, err := stew.PathExists(downloadPath)
 			stew.CatchAndExit(err)
 			if downloadPathExists {

--- a/lib/stewfile.go
+++ b/lib/stewfile.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/marwanhawari/stew/constants"
 )
@@ -131,10 +131,10 @@ type SystemInfo struct {
 func NewSystemInfo(stewPath string) SystemInfo {
 	var systemInfo SystemInfo
 	systemInfo.StewPath = stewPath
-	systemInfo.StewBinPath = path.Join(stewPath, "bin")
-	systemInfo.StewPkgPath = path.Join(stewPath, "pkg")
-	systemInfo.StewLockFilePath = path.Join(stewPath, "Stewfile.lock.json")
-	systemInfo.StewTmpPath = path.Join(stewPath, "tmp")
+	systemInfo.StewBinPath = filepath.Join(stewPath, "bin")
+	systemInfo.StewPkgPath = filepath.Join(stewPath, "pkg")
+	systemInfo.StewLockFilePath = filepath.Join(stewPath, "Stewfile.lock.json")
+	systemInfo.StewTmpPath = filepath.Join(stewPath, "tmp")
 	systemInfo.Os = getOS()
 	systemInfo.Arch = getArch()
 
@@ -143,8 +143,8 @@ func NewSystemInfo(stewPath string) SystemInfo {
 
 // DeleteAssetAndBinary will delete the asset from the ~/.stew/pkg path and delete the binary from the ~/.stew/bin path
 func DeleteAssetAndBinary(stewPkgPath, stewBinPath, asset, binary string) error {
-	assetPath := path.Join(stewPkgPath, asset)
-	binPath := path.Join(stewBinPath, binary)
+	assetPath := filepath.Join(stewPkgPath, asset)
+	binPath := filepath.Join(stewBinPath, binary)
 	err := os.RemoveAll(assetPath)
 	if err != nil {
 		return err

--- a/lib/stewfile_test.go
+++ b/lib/stewfile_test.go
@@ -3,7 +3,7 @@ package stew
 import (
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"reflect"
 	"runtime"
 	"testing"
@@ -69,7 +69,7 @@ func Test_readLockFileJSON(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tempDir := t.TempDir()
-			lockFilePath := path.Join(tempDir, "Stewfile.lock.json")
+			lockFilePath := filepath.Join(tempDir, "Stewfile.lock.json")
 			WriteLockFileJSON(testLockfile, lockFilePath)
 
 			got, err := readLockFileJSON(lockFilePath)
@@ -97,7 +97,7 @@ func TestWriteLockFileJSON(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tempDir := t.TempDir()
-			lockFilePath := path.Join(tempDir, "Stewfile.lock.json")
+			lockFilePath := filepath.Join(tempDir, "Stewfile.lock.json")
 
 			if err := WriteLockFileJSON(testLockfile, lockFilePath); (err != nil) != tt.wantErr {
 				t.Errorf("WriteLockFileJSON() error = %v, wantErr %v", err, tt.wantErr)
@@ -201,7 +201,7 @@ func TestReadStewfileContents(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			tempDir := t.TempDir()
-			testStewfilePath := path.Join(tempDir, "Stewfile")
+			testStewfilePath := filepath.Join(tempDir, "Stewfile")
 			ioutil.WriteFile(testStewfilePath, []byte(testStewfileContents), 0644)
 
 			got, err := ReadStewfileContents(testStewfilePath)
@@ -241,7 +241,7 @@ func TestNewLockFile(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			tempDir := t.TempDir()
-			lockFilePath := path.Join(tempDir, "Stewfile.lock.json")
+			lockFilePath := filepath.Join(tempDir, "Stewfile.lock.json")
 			WriteLockFileJSON(testLockfile, lockFilePath)
 
 			got, err := NewLockFile(lockFilePath, tt.args.userOS, tt.args.userArch)
@@ -279,7 +279,7 @@ func TestNewLockFileDoesntExist(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			tempDir := t.TempDir()
-			lockFilePath := path.Join(tempDir, "Stewfile.lock.json")
+			lockFilePath := filepath.Join(tempDir, "Stewfile.lock.json")
 
 			got, err := NewLockFile(lockFilePath, tt.args.userOS, tt.args.userArch)
 			if (err != nil) != tt.wantErr {
@@ -309,10 +309,10 @@ func TestNewSystemInfo(t *testing.T) {
 				Os:               runtime.GOOS,
 				Arch:             runtime.GOARCH,
 				StewPath:         tempDir,
-				StewBinPath:      path.Join(tempDir, "bin"),
-				StewPkgPath:      path.Join(tempDir, "pkg"),
-				StewLockFilePath: path.Join(tempDir, "Stewfile.lock.json"),
-				StewTmpPath:      path.Join(tempDir, "tmp"),
+				StewBinPath:      filepath.Join(tempDir, "bin"),
+				StewPkgPath:      filepath.Join(tempDir, "pkg"),
+				StewLockFilePath: filepath.Join(tempDir, "Stewfile.lock.json"),
+				StewTmpPath:      filepath.Join(tempDir, "tmp"),
 			}
 
 			got := NewSystemInfo(tempDir)
@@ -336,10 +336,10 @@ func TestDeleteAssetAndBinary(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tempDir := t.TempDir()
-			os.MkdirAll(path.Join(tempDir, "pkg"), 0755)
-			testStewAssetPath := path.Join(tempDir, "pkg", "testAsset.tar.gz")
-			os.MkdirAll(path.Join(tempDir, "bin"), 0755)
-			testStewBinaryPath := path.Join(tempDir, "bin", "testBinary")
+			os.MkdirAll(filepath.Join(tempDir, "pkg"), 0755)
+			testStewAssetPath := filepath.Join(tempDir, "pkg", "testAsset.tar.gz")
+			os.MkdirAll(filepath.Join(tempDir, "bin"), 0755)
+			testStewBinaryPath := filepath.Join(tempDir, "bin", "testBinary")
 
 			ioutil.WriteFile(testStewAssetPath, []byte("This is a test asset"), 0644)
 			ioutil.WriteFile(testStewBinaryPath, []byte("This is a test binary"), 0644)
@@ -351,7 +351,7 @@ func TestDeleteAssetAndBinary(t *testing.T) {
 				t.Errorf("Either the asset or the binary does not exist yet")
 			}
 
-			if err := DeleteAssetAndBinary(path.Dir(testStewAssetPath), path.Dir(testStewBinaryPath), path.Base(testStewAssetPath), path.Base(testStewBinaryPath)); (err != nil) != tt.wantErr {
+			if err := DeleteAssetAndBinary(filepath.Dir(testStewAssetPath), filepath.Dir(testStewBinaryPath), filepath.Base(testStewAssetPath), filepath.Base(testStewBinaryPath)); (err != nil) != tt.wantErr {
 				t.Errorf("DeleteAssetAndBinary() error = %v, wantErr %v", err, tt.wantErr)
 			}
 

--- a/lib/ui.go
+++ b/lib/ui.go
@@ -55,3 +55,21 @@ func WarningPromptConfirm(message string) (bool, error) {
 
 	return result, nil
 }
+
+// WarningPromptInput launches the input UI with a warning styling
+func warningPromptInput(message string, defaultInput string) (string, error) {
+	result := ""
+	prompt := &survey.Input{
+		Message: message,
+		Default: defaultInput,
+	}
+	err := survey.AskOne(prompt, &result, survey.WithIcons(func(icons *survey.IconSet) {
+		icons.Question.Text = "!"
+		icons.Question.Format = "yellow+hb"
+	}))
+	if err != nil {
+		return "", ExitUserSelectionError{Err: err}
+	}
+
+	return result, nil
+}

--- a/lib/ui.go
+++ b/lib/ui.go
@@ -56,7 +56,7 @@ func WarningPromptConfirm(message string) (bool, error) {
 	return result, nil
 }
 
-// WarningPromptInput launches the input UI with a warning styling
+// warningPromptInput launches the input UI with a warning styling
 func warningPromptInput(message string, defaultInput string) (string, error) {
 	result := ""
 	prompt := &survey.Input{

--- a/lib/util.go
+++ b/lib/util.go
@@ -194,7 +194,7 @@ func getBinary(filePaths []string, repo string) (string, string, error) {
 				return "", "", err
 			}
 			binaryName = filepath.Base(binaryFile)
-			binaryName, err = renameBinary(binaryName)
+			binaryName, err = PromptRenameBinary(binaryName)
 			if err != nil {
 				return "", "", nil
 			}
@@ -311,7 +311,7 @@ func extractBinary(downloadedFilePath, tmpExtractionPath string) error {
 	} else {
 		originalBinaryName := filepath.Base(downloadedFilePath)
 
-		renamedBinaryName, err := renameBinary(originalBinaryName)
+		renamedBinaryName, err := PromptRenameBinary(originalBinaryName)
 		if err != nil {
 			return err
 		}
@@ -403,8 +403,8 @@ func InstallBinary(downloadedFilePath string, repo string, systemInfo SystemInfo
 	return binaryName, nil
 }
 
-// renameBinary takes in the original name of the binary and will return the new name of the binary.
-func renameBinary(originalBinaryName string) (string, error) {
+// PromptRenameBinary takes in the original name of the binary and will return the new name of the binary.
+func PromptRenameBinary(originalBinaryName string) (string, error) {
 	renamedBinaryName, err := warningPromptInput("Rename the binary?", originalBinaryName)
 	if err != nil {
 		return "", err

--- a/lib/util_test.go
+++ b/lib/util_test.go
@@ -3,7 +3,7 @@ package stew
 import (
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"reflect"
 	"runtime"
 	"testing"
@@ -72,7 +72,7 @@ func Test_isExecutableFile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tempDir := t.TempDir()
-			testExecutableFilePath := path.Join(tempDir, tt.args.filePath)
+			testExecutableFilePath := filepath.Join(tempDir, tt.args.filePath)
 			if tt.want {
 				ioutil.WriteFile(testExecutableFilePath, []byte("An executable file"), 0755)
 			} else {
@@ -121,7 +121,7 @@ func TestPathExists(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tempDir := t.TempDir()
-			testFilePath := path.Join(tempDir, tt.args.path)
+			testFilePath := filepath.Join(tempDir, tt.args.path)
 			if tt.want {
 				ioutil.WriteFile(testFilePath, []byte("A test file"), 0644)
 			}
@@ -151,7 +151,7 @@ func TestGetStewPath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			homeDir, _ := os.UserHomeDir()
-			testStewPath := path.Join(homeDir, ".stew")
+			testStewPath := filepath.Join(homeDir, ".stew")
 			stewPathExists, _ := PathExists(testStewPath)
 			if !stewPathExists {
 				os.MkdirAll(testStewPath, 0755)
@@ -200,7 +200,7 @@ func TestDownloadFile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tempDir := t.TempDir()
-			testDownloadPath := path.Join(tempDir, path.Base(tt.args.url))
+			testDownloadPath := filepath.Join(tempDir, filepath.Base(tt.args.url))
 			if err := DownloadFile(testDownloadPath, tt.args.url); (err != nil) != tt.wantErr {
 				t.Errorf("DownloadFile() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -235,8 +235,8 @@ func Test_copyFile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tempDir := t.TempDir()
-			srcFilePath := path.Join(tempDir, tt.args.srcFile)
-			destFilePath := path.Join(tempDir, tt.args.destFile)
+			srcFilePath := filepath.Join(tempDir, tt.args.srcFile)
+			destFilePath := filepath.Join(tempDir, tt.args.destFile)
 
 			ioutil.WriteFile(srcFilePath, []byte("A test file"), 0644)
 
@@ -280,11 +280,11 @@ func Test_walkDir(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tempDir := t.TempDir()
 
-			ioutil.WriteFile(path.Join(tempDir, "testFile.txt"), []byte("A test file"), 0644)
-			os.MkdirAll(path.Join(tempDir, "bin"), 0755)
-			ioutil.WriteFile(path.Join(tempDir, "bin", "binDirTestFile.txt"), []byte("Another test file"), 0644)
+			ioutil.WriteFile(filepath.Join(tempDir, "testFile.txt"), []byte("A test file"), 0644)
+			os.MkdirAll(filepath.Join(tempDir, "bin"), 0755)
+			ioutil.WriteFile(filepath.Join(tempDir, "bin", "binDirTestFile.txt"), []byte("Another test file"), 0644)
 
-			want := []string{path.Join(tempDir, "bin", "binDirTestFile.txt"), path.Join(tempDir, "testFile.txt")}
+			want := []string{filepath.Join(tempDir, "bin", "binDirTestFile.txt"), filepath.Join(tempDir, "testFile.txt")}
 
 			got, err := walkDir(tempDir)
 			if (err != nil) != tt.wantErr {
@@ -337,15 +337,15 @@ func Test_getBinary(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tempDir := t.TempDir()
 
-			testBinaryFilePath := path.Join(tempDir, tt.binaryName)
+			testBinaryFilePath := filepath.Join(tempDir, tt.binaryName)
 			ioutil.WriteFile(testBinaryFilePath, []byte("An executable file"), 0755)
-			testNonBinaryFilePath := path.Join(tempDir, "testNonBinary")
+			testNonBinaryFilePath := filepath.Join(tempDir, "testNonBinary")
 			ioutil.WriteFile(testNonBinaryFilePath, []byte("Not an executable file"), 0644)
 
 			testFilePaths := []string{testBinaryFilePath, testNonBinaryFilePath}
 
-			wantBinaryFile := path.Join(tempDir, tt.binaryName)
-			wantBinaryName := path.Base(wantBinaryFile)
+			wantBinaryFile := filepath.Join(tempDir, tt.binaryName)
+			wantBinaryName := filepath.Base(wantBinaryFile)
 
 			got, got1, err := getBinary(testFilePaths, tt.args.repo)
 			if (err != nil) != tt.wantErr {
@@ -385,7 +385,7 @@ func Test_getBinaryError(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tempDir := t.TempDir()
 
-			testNonBinaryFilePath := path.Join(tempDir, "testNonBinary")
+			testNonBinaryFilePath := filepath.Join(tempDir, "testNonBinary")
 			ioutil.WriteFile(testNonBinaryFilePath, []byte("Not an executable file"), 0644)
 
 			testFilePaths := []string{testNonBinaryFilePath}
@@ -702,8 +702,8 @@ func Test_extractBinary(t *testing.T) {
 		{
 			name: "test1",
 			args: args{
-				downloadedFilePath: path.Join(t.TempDir(), "ppath-v0.0.3-darwin-arm64.tar.gz"),
-				tmpExtractionPath:  path.Join(t.TempDir(), "tmp"),
+				downloadedFilePath: filepath.Join(t.TempDir(), "ppath-v0.0.3-darwin-arm64.tar.gz"),
+				tmpExtractionPath:  filepath.Join(t.TempDir(), "tmp"),
 			},
 			url:     "https://github.com/marwanhawari/ppath/releases/download/v0.0.3/ppath-v0.0.3-darwin-arm64.tar.gz",
 			wantErr: false,
@@ -735,7 +735,7 @@ func TestInstallBinary(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tempDir := t.TempDir()
-			stewPath := path.Join(tempDir, ".stew")
+			stewPath := filepath.Join(tempDir, ".stew")
 
 			repo := "ppath"
 			systemInfo := NewSystemInfo(stewPath)
@@ -759,7 +759,7 @@ func TestInstallBinary(t *testing.T) {
 				},
 			}
 
-			downloadedFilePath := path.Join(systemInfo.StewPkgPath, "ppath-v0.0.3-darwin-arm64.tar.gz")
+			downloadedFilePath := filepath.Join(systemInfo.StewPkgPath, "ppath-v0.0.3-darwin-arm64.tar.gz")
 			err := DownloadFile(downloadedFilePath, "https://github.com/marwanhawari/ppath/releases/download/v0.0.3/ppath-v0.0.3-darwin-arm64.tar.gz")
 
 			if err != nil {
@@ -794,7 +794,7 @@ func TestInstallBinary_Fail(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tempDir := t.TempDir()
-			stewPath := path.Join(tempDir, ".stew")
+			stewPath := filepath.Join(tempDir, ".stew")
 
 			repo := "ppath"
 			systemInfo := NewSystemInfo(stewPath)
@@ -818,7 +818,7 @@ func TestInstallBinary_Fail(t *testing.T) {
 				},
 			}
 
-			downloadedFilePath := path.Join(systemInfo.StewPkgPath, "ppath-v0.0.3-darwin-arm64.tar.gz")
+			downloadedFilePath := filepath.Join(systemInfo.StewPkgPath, "ppath-v0.0.3-darwin-arm64.tar.gz")
 			err := DownloadFile(downloadedFilePath, "https://github.com/marwanhawari/ppath/releases/download/v0.0.3/ppath-v0.0.3-darwin-arm64.tar.gz")
 
 			if err != nil {

--- a/main.go
+++ b/main.go
@@ -72,6 +72,15 @@ func main() {
 				},
 			},
 			{
+				Name:    "rename",
+				Usage:   "Rename an installed binary using a prompt UI. [Ex: stew rename fzf]",
+				Aliases: []string{"re"},
+				Action: func(c *cli.Context) error {
+					cmd.Rename(c.Args().First())
+					return nil
+				},
+			},
+			{
 				Name:    "list",
 				Usage:   "List installed binaries [Ex: stew list]",
 				Aliases: []string{"ls"},


### PR DESCRIPTION
This PR adds a `rename` subcommand to allow users to rename binaries. This is preferred over using an alias in your `.zshrc` or `.bashrc` because renaming a binary with `rename` will update the `Stewfile.lock.json` as well as the binary name itself. This means that commands like `stew uninstall <renamedBinary>` and `stew upgrade <renamedBinary>` will work, which is not true if you use an alias.

Users will also automatically be prompted to rename a binary if:
1. The asset itself is the binary. Often these have names like binary-v0.0.1-darwin-arm64, which is not the name that people want to type into the command line.
2. If the binary is not automatically detected inside an archived asset (which can happen if 0 or >1 executable files are found in an archive). After selecting the binary, they will be prompted to rename it.

Finally, this PR switch out any usage of the `path` library in favor of the `filepath` library which uses `/` or `\` in an operating-system compatible way. `path` only uses `/`.