### PR TITLE
Allow user configuration and support XDG spec by default

### DIFF
--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -11,14 +11,15 @@ import (
 
 // Browse is executed when you run `stew browse`
 func Browse(cliInput string) {
+
+	userOS, userArch, _, systemInfo, err := stew.Initialize()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
 	sp := constants.LoadingSpinner
 
-	stewPath, err := stew.GetStewPath()
-	stew.CatchAndExit(err)
-	systemInfo := stew.NewSystemInfo(stewPath)
-
-	userOS := systemInfo.Os
-	userArch := systemInfo.Arch
 	stewBinPath := systemInfo.StewBinPath
 	stewPkgPath := systemInfo.StewPkgPath
 	stewLockFilePath := systemInfo.StewLockFilePath

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/marwanhawari/stew/constants"
+	stew "github.com/marwanhawari/stew/lib"
+)
+
+func Config() {
+
+	userOS, _, stewConfig, _, err := stew.Initialize()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	stewConfigFilePath, err := stew.GetStewConfigFilePath(userOS)
+	stew.CatchAndExit(err)
+
+	inputStewPath, err := stew.PromptInput("Set the stewPath. This will contain all stew data other than the binaries.", stewConfig.StewPath)
+	stew.CatchAndExit(err)
+	inputStewBinPath, err := stew.PromptInput("Set the stewBinPath. This is where the binaries will be installed by stew.", stewConfig.StewBinPath)
+	stew.CatchAndExit(err)
+
+	fullStewPath, err := stew.ResolveTilde(inputStewPath)
+	stew.CatchAndExit(err)
+	fullStewBinPath, err := stew.ResolveTilde(inputStewBinPath)
+	stew.CatchAndExit(err)
+
+	newStewConfig := stew.StewConfig{StewPath: fullStewPath, StewBinPath: fullStewBinPath}
+	err = stew.WriteStewConfigJSON(newStewConfig, stewConfigFilePath)
+	stew.CatchAndExit(err)
+
+	fmt.Printf("📄 Updated %v\n", constants.GreenColor(stewConfigFilePath))
+}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -13,6 +13,13 @@ import (
 // Install is executed when you run `stew install`
 func Install(cliInputs []string) {
 	var err error
+
+	userOS, userArch, _, systemInfo, err := stew.Initialize()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
 	for _, cliInput := range cliInputs {
 		if strings.Contains(cliInput, "Stewfile") {
 			cliInputs, err = stew.ReadStewfileContents(cliInput)
@@ -28,12 +35,6 @@ func Install(cliInputs []string) {
 	for _, cliInput := range cliInputs {
 		sp := constants.LoadingSpinner
 
-		stewPath, err := stew.GetStewPath()
-		stew.CatchAndExit(err)
-		systemInfo := stew.NewSystemInfo(stewPath)
-
-		userOS := systemInfo.Os
-		userArch := systemInfo.Arch
 		stewBinPath := systemInfo.StewBinPath
 		stewPkgPath := systemInfo.StewPkgPath
 		stewLockFilePath := systemInfo.StewLockFilePath

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	stew "github.com/marwanhawari/stew/lib"
 )
@@ -9,12 +10,12 @@ import (
 // List is executed when you run `stew list`
 func List(cliTagsFlag bool, cliAssetsFlag bool) {
 
-	stewPath, err := stew.GetStewPath()
-	stew.CatchAndExit(err)
-	systemInfo := stew.NewSystemInfo(stewPath)
+	userOS, userArch, _, systemInfo, err := stew.Initialize()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
-	userOS := systemInfo.Os
-	userArch := systemInfo.Arch
 	stewLockFilePath := systemInfo.StewLockFilePath
 
 	lockFile, err := stew.NewLockFile(stewLockFilePath, userOS, userArch)

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -12,15 +12,15 @@ import (
 // Rename is executed when you run `stew rename`
 func Rename(cliInput string) {
 
-	err := stew.ValidateCLIInput(cliInput)
+	userOS, userArch, _, systemInfo, err := stew.Initialize()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	err = stew.ValidateCLIInput(cliInput)
 	stew.CatchAndExit(err)
 
-	stewPath, err := stew.GetStewPath()
-	stew.CatchAndExit(err)
-	systemInfo := stew.NewSystemInfo(stewPath)
-
-	userOS := systemInfo.Os
-	userArch := systemInfo.Arch
 	stewBinPath := systemInfo.StewBinPath
 	stewLockFilePath := systemInfo.StewLockFilePath
 

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/marwanhawari/stew/constants"
 	stew "github.com/marwanhawari/stew/lib"
@@ -9,6 +10,13 @@ import (
 
 // Uninstall is executed when you run `stew uninstall`
 func Uninstall(cliFlag bool, binaryName string) {
+
+	userOS, userArch, _, systemInfo, err := stew.Initialize()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
 	if cliFlag && binaryName != "" {
 		stew.CatchAndExit(stew.CLIFlagAndInputError{})
 	} else if !cliFlag {
@@ -16,12 +24,6 @@ func Uninstall(cliFlag bool, binaryName string) {
 		stew.CatchAndExit(err)
 	}
 
-	stewPath, err := stew.GetStewPath()
-	stew.CatchAndExit(err)
-	systemInfo := stew.NewSystemInfo(stewPath)
-
-	userOS := systemInfo.Os
-	userArch := systemInfo.Arch
 	stewBinPath := systemInfo.StewBinPath
 	stewPkgPath := systemInfo.StewPkgPath
 	stewLockFilePath := systemInfo.StewLockFilePath

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -11,6 +11,13 @@ import (
 
 // Upgrade is executed when you run `stew upgrade`
 func Upgrade(cliFlag bool, binaryName string) {
+
+	userOS, userArch, _, systemInfo, err := stew.Initialize()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
 	if cliFlag && binaryName != "" {
 		stew.CatchAndExit(stew.CLIFlagAndInputError{})
 	} else if !cliFlag {
@@ -20,12 +27,6 @@ func Upgrade(cliFlag bool, binaryName string) {
 
 	sp := constants.LoadingSpinner
 
-	stewPath, err := stew.GetStewPath()
-	stew.CatchAndExit(err)
-	systemInfo := stew.NewSystemInfo(stewPath)
-
-	userOS := systemInfo.Os
-	userArch := systemInfo.Arch
 	stewPkgPath := systemInfo.StewPkgPath
 	stewTmpPath := systemInfo.StewTmpPath
 	stewLockFilePath := systemInfo.StewLockFilePath

--- a/install.sh
+++ b/install.sh
@@ -1,25 +1,56 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # This install script does 3 things:
-# 1. Create the ~/.stew directory structure
+# 1. Create the stew directory structure
 # 2. Download the stew binary
-# 3. Add ~/.stew/bin to PATH in ~/.zshrc or ~/.bashrc
+# 3. Add the stew binary path to PATH in ~/.zshrc or ~/.bashrc
 
 os=""
 arch=""
 exe=""
+defaultStewPath=""
+configPath=""
 
 # Detect os
 case "$(uname -s)" in
     Darwin)
         os="darwin"
+
+        if [ -z "$XDG_DATA_HOME" ]
+        then
+            defaultStewPath="$HOME/.local/share/stew"
+        else
+            defaultStewPath="$XDG_DATA_HOME/stew"
+        fi
+
+        if [ -z "$XDG_CONFIG_HOME" ]
+        then
+            configPath="$HOME/.config/stew"
+        else
+            configPath="$XDG_CONFIG_HOME/stew"
+        fi
         ;;
     Linux)
         os="linux"
+        if [ -z "$XDG_DATA_HOME" ]
+        then
+            defaultStewPath="$HOME/.local/share/stew"
+        else
+            defaultStewPath="$XDG_DATA_HOME/stew"
+        fi
+
+        if [ -z "$XDG_CONFIG_HOME" ]
+        then
+            configPath="$HOME/.config/stew"
+        else
+            configPath="$XDG_CONFIG_HOME/stew"
+        fi
         ;;
     CYGWIN*|MSYS*|MINGW*)
         os="windows"
         exe=".exe"
+        defaultStewPath="$HOME/AppData/Local/stew"
+        configPath="$HOME/AppData/Local/stew/Config"
         ;;
 esac
 
@@ -38,27 +69,77 @@ esac
 
 if [ "$os" = "" ] || [ "$arch" = "" ]
 then
-    echo "\033[31m\033[1mError:\033[0m Your current OS/arch is not supported by stew"
+    echo ""
+    echo "|||||||||||||||||||||"
+    echo "||      Error      ||"
+    echo "|||||||||||||||||||||"
+    echo ""
+    echo "Your current OS/arch is not supported by stew"
+    echo ""
     exit 1
 fi
 
-# 1. Create the ~/.stew directory structure
-mkdir -p "$HOME"/.stew/bin
-mkdir -p "$HOME"/.stew/pkg
+# 1. Create the stew directory structure
+stewPath=""
+stewBinPath=""
 
-# 2. Download the stew binary
-curl -o "$HOME"/.stew/bin/stew${exe} -fsSL https://github.com/marwanhawari/stew/releases/latest/download/stew-${os}-${arch}${exe}
-chmod +x "$HOME"/.stew/bin/stew${exe}
-
-# 3. Add ~/.stew/bin to PATH in ~/.zshrc or ~/.bashrc
-if [ -f "$HOME"/.zshrc ]
+read -r -t 60 -p "Set the stewPath. This will contain all stew data other than the binaries. (${defaultStewPath}): " stewPathInput
+if [ -z "$stewPathInput" ]
 then
-    echo 'export PATH="$HOME/.stew/bin:$PATH"' >> "$HOME"/.zshrc
-elif [ -f "$HOME"/.bashrc ]
-then
-    echo 'export PATH="$HOME/.stew/bin:$PATH"' >> "$HOME"/.bashrc
+    stewPath="${defaultStewPath}"
 else
-    echo "Make sure to add $HOME/.stew/bin to PATH"
+    stewPath="${stewPathInput/#~/$HOME}"
+    stewPath="${stewPath/#\$HOME/$HOME}"
+    stewPath="${stewPath/#\$PWD/$PWD}"
+    if [ -x "$(command -v dirname)" ] && [ -x "$(command -v basename)" ]
+    then
+        stewPath="$(cd "$(dirname "$stewPath")" || exit; pwd)/$(basename "$stewPath")"
+    fi
 fi
 
-echo "\033[32m\033[1mSuccess:\033[0m Start a new terminal session to start using stew"
+read -r -t 60 -p "Set the stewBinPath. This is where the binaries will be installed by stew. (${defaultStewPath}/bin): " stewBinPathInput
+if [ -z "$stewBinPathInput" ]
+then
+    stewBinPath="${defaultStewPath}/bin"
+else
+    stewBinPath="${stewBinPathInput/#~/$HOME}"
+    stewBinPath="${stewBinPath/#\$HOME/$HOME}"
+    stewBinPath="${stewBinPath/#\$PWD/$PWD}"
+    if [ -x "$(command -v dirname)" ] && [ -x "$(command -v basename)" ]
+    then
+        stewBinPath="$(cd "$(dirname "$stewBinPath")" || exit; pwd)/$(basename "$stewBinPath")"
+    fi
+fi
+
+mkdir -p "${stewPath}/bin"
+mkdir -p "${stewPath}/pkg"
+mkdir -p "${stewBinPath}"
+mkdir -p "${configPath}"
+
+echo "{
+	\"stewPath\": \"${stewPath}\",
+	\"stewBinPath\": \"${stewBinPath}\"
+}" > "${configPath}/config.json"
+
+# 2. Download the stew binary
+curl -o "${stewBinPath}/stew${exe}" -fsSL https://github.com/marwanhawari/stew/releases/latest/download/stew-${os}-${arch}${exe}
+chmod +x "${stewBinPath}/stew${exe}"
+
+# 3. Add the stew binary path to PATH in ~/.zshrc or ~/.bashrc
+if [ -f "$HOME"/.zshrc ]
+then
+    echo "export PATH=\"${stewBinPath}:\$PATH\"" >> "$HOME"/.zshrc
+elif [ -f "$HOME"/.bashrc ]
+then
+    echo "export PATH=\"${stewBinPath}:\$PATH\"" >> "$HOME"/.bashrc
+else
+    echo "Make sure to add ${stewBinPath} to PATH"
+fi
+
+echo ""
+echo "|||||||||||||||||||||"
+echo "||     Success     ||"
+echo "|||||||||||||||||||||"
+echo ""
+echo "Start a new terminal session to start using stew"
+echo ""

--- a/lib/config.go
+++ b/lib/config.go
@@ -73,9 +73,9 @@ func GetStewConfigFilePath(userOS string) (string, error) {
 	default:
 		xdgConfigHomePath := os.Getenv("XDG_CONFIG_HOME")
 		if xdgConfigHomePath == "" {
-			stewConfigFilePath = filepath.Join(xdgConfigHomePath, "stew", "config.json")
-		} else {
 			stewConfigFilePath = filepath.Join(homeDir, ".config", "stew", "config.json")
+		} else {
+			stewConfigFilePath = filepath.Join(xdgConfigHomePath, "stew", "config.json")
 		}
 	}
 

--- a/lib/config.go
+++ b/lib/config.go
@@ -1,0 +1,231 @@
+package stew
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// GetDefaultStewPath will return the default path to the top-level stew directory
+func GetDefaultStewPath(userOS string) (string, error) {
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	var stewPath string
+	switch userOS {
+	case "windows":
+		stewPath = filepath.Join(homeDir, "AppData", "Local", "stew")
+	default:
+		xdgDataHomePath := os.Getenv("XDG_DATA_HOME")
+		if xdgDataHomePath == "" {
+			stewPath = filepath.Join(homeDir, ".local", "share", "stew")
+		} else {
+			stewPath = filepath.Join(xdgDataHomePath, "stew")
+
+		}
+	}
+
+	return stewPath, nil
+}
+
+// GetDefaultStewBinPath will return the default path where binaries are installed by stew
+func GetDefaultStewBinPath(userOS string) (string, error) {
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	var stewBinPath string
+	switch userOS {
+	case "windows":
+		stewBinPath = filepath.Join(homeDir, "AppData", "Local", "stew", "bin")
+	default:
+		xdgDataHomePath := os.Getenv("XDG_DATA_HOME")
+		if xdgDataHomePath == "" {
+			stewBinPath = filepath.Join(homeDir, ".local", "share", "stew", "bin")
+		} else {
+			stewBinPath = filepath.Join(xdgDataHomePath, "stew", "bin")
+
+		}
+	}
+
+	return stewBinPath, nil
+}
+
+// GetStewConfigFilePath will return the stew config file path
+func GetStewConfigFilePath(userOS string) (string, error) {
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	var stewConfigFilePath string
+	switch userOS {
+	case "windows":
+		stewConfigFilePath = filepath.Join(homeDir, "AppData", "Local", "stew", "Config", "config.json")
+	default:
+		xdgConfigHomePath := os.Getenv("XDG_CONFIG_HOME")
+		if xdgConfigHomePath == "" {
+			stewConfigFilePath = filepath.Join(xdgConfigHomePath, "stew", "config.json")
+		} else {
+			stewConfigFilePath = filepath.Join(homeDir, ".config", "stew", "config.json")
+		}
+	}
+
+	return stewConfigFilePath, nil
+}
+
+// StewConfig contains all the stew configuration data
+type StewConfig struct {
+	StewPath    string `json:"stewPath"`
+	StewBinPath string `json:"stewBinPath"`
+}
+
+func readStewConfigJSON(stewConfigFilePath string) (StewConfig, error) {
+
+	stewConfigFileBytes, err := ioutil.ReadFile(stewConfigFilePath)
+	if err != nil {
+		return StewConfig{}, err
+	}
+
+	var stewConfig StewConfig
+	err = json.Unmarshal(stewConfigFileBytes, &stewConfig)
+	if err != nil {
+		return StewConfig{}, err
+	}
+
+	return stewConfig, nil
+}
+
+// WriteStewConfigJSON will write the config JSON file
+func WriteStewConfigJSON(stewConfigFileJSON StewConfig, outputPath string) error {
+
+	stewConfigFileBytes, err := json.MarshalIndent(stewConfigFileJSON, "", "\t")
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(outputPath, stewConfigFileBytes, 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// NewStewConfig creates a new instance of the StewConfig struct
+func NewStewConfig(userOS string) (StewConfig, error) {
+	var stewConfig StewConfig
+
+	stewConfigFilePath, err := GetStewConfigFilePath(userOS)
+	if err != nil {
+		return StewConfig{}, err
+	}
+	defaultStewPath, err := GetDefaultStewPath(userOS)
+	if err != nil {
+		return StewConfig{}, err
+	}
+	defaultStewBinPath, err := GetDefaultStewBinPath(userOS)
+	if err != nil {
+		return StewConfig{}, err
+	}
+
+	configExists, err := PathExists(stewConfigFilePath)
+	if err != nil {
+		return StewConfig{}, err
+	}
+	if configExists {
+		stewConfig, err = readStewConfigJSON(stewConfigFilePath)
+		if err != nil {
+			return StewConfig{}, err
+		}
+	}
+
+	if stewConfig.StewPath == "" {
+		stewConfig.StewPath = defaultStewPath
+	}
+
+	if stewConfig.StewBinPath == "" {
+		stewConfig.StewBinPath = defaultStewBinPath
+	}
+
+	err = createStewDirsAndFiles(stewConfig, stewConfigFilePath)
+	if err != nil {
+		return StewConfig{}, err
+	}
+
+	return stewConfig, nil
+}
+
+func createStewDirsAndFiles(stewConfig StewConfig, stewConfigFilePath string) error {
+	var err error
+
+	err = os.MkdirAll(stewConfig.StewPath, 0755)
+	if err != nil {
+		return err
+	}
+	err = os.MkdirAll(filepath.Join(stewConfig.StewPath, "bin"), 0755)
+	if err != nil {
+		return err
+	}
+	err = os.MkdirAll(filepath.Join(stewConfig.StewPath, "pkg"), 0755)
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(stewConfig.StewBinPath, 0755)
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(filepath.Dir(stewConfigFilePath), 0755)
+	if err != nil {
+		return err
+	}
+	err = WriteStewConfigJSON(stewConfig, stewConfigFilePath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// SystemInfo contains system specific info like OS, arch, and ~/.stew paths
+type SystemInfo struct {
+	StewPath         string
+	StewBinPath      string
+	StewPkgPath      string
+	StewLockFilePath string
+	StewTmpPath      string
+}
+
+// NewSystemInfo creates a new instance of the SystemInfo struct
+func NewSystemInfo(stewConfig StewConfig) SystemInfo {
+	var systemInfo SystemInfo
+	systemInfo.StewPath = stewConfig.StewPath
+	systemInfo.StewBinPath = stewConfig.StewBinPath
+	systemInfo.StewPkgPath = filepath.Join(stewConfig.StewPath, "pkg")
+	systemInfo.StewLockFilePath = filepath.Join(stewConfig.StewPath, "Stewfile.lock.json")
+	systemInfo.StewTmpPath = filepath.Join(stewConfig.StewPath, "tmp")
+	return systemInfo
+}
+
+// Initialize returns pertinent initialization information like OS, arch, configuration, and system info
+func Initialize() (string, string, StewConfig, SystemInfo, error) {
+	userOS := runtime.GOOS
+	userArch := runtime.GOARCH
+	stewConfig, err := NewStewConfig(userOS)
+	if err != nil {
+		return "", "", StewConfig{}, SystemInfo{}, err
+	}
+	systemInfo := NewSystemInfo(stewConfig)
+
+	return userOS, userArch, stewConfig, systemInfo, nil
+}

--- a/lib/config_test.go
+++ b/lib/config_test.go
@@ -1,0 +1,52 @@
+package stew
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetDefaultStewPath(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Errorf("Could not get os.UserHomeDir()")
+	}
+	type args struct {
+		userOS string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "test1",
+			args: args{
+				userOS: "darwin",
+			},
+			want:    filepath.Join(homeDir, ".local", "share", "stew"),
+			wantErr: false,
+		},
+		{
+			name: "test2",
+			args: args{
+				userOS: "windows",
+			},
+			want:    filepath.Join(homeDir, "AppData", "Local", "stew"),
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetDefaultStewPath(tt.args.userOS)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetDefaultStewPath() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetDefaultStewPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/lib/stewfile.go
+++ b/lib/stewfile.go
@@ -116,31 +116,6 @@ func NewLockFile(stewLockFilePath, userOS, userArch string) (LockFile, error) {
 	return lockFile, nil
 }
 
-// SystemInfo contains system specific info like OS, arch, and ~/.stew paths
-type SystemInfo struct {
-	Os               string
-	Arch             string
-	StewPath         string
-	StewBinPath      string
-	StewPkgPath      string
-	StewLockFilePath string
-	StewTmpPath      string
-}
-
-// NewSystemInfo creates a new instance of the SystemInfo struct
-func NewSystemInfo(stewPath string) SystemInfo {
-	var systemInfo SystemInfo
-	systemInfo.StewPath = stewPath
-	systemInfo.StewBinPath = filepath.Join(stewPath, "bin")
-	systemInfo.StewPkgPath = filepath.Join(stewPath, "pkg")
-	systemInfo.StewLockFilePath = filepath.Join(stewPath, "Stewfile.lock.json")
-	systemInfo.StewTmpPath = filepath.Join(stewPath, "tmp")
-	systemInfo.Os = getOS()
-	systemInfo.Arch = getArch()
-
-	return systemInfo
-}
-
 // DeleteAssetAndBinary will delete the asset from the ~/.stew/pkg path and delete the binary from the ~/.stew/bin path
 func DeleteAssetAndBinary(stewPkgPath, stewBinPath, asset, binary string) error {
 	assetPath := filepath.Join(stewPkgPath, asset)

--- a/lib/stewfile_test.go
+++ b/lib/stewfile_test.go
@@ -293,34 +293,38 @@ func TestNewLockFileDoesntExist(t *testing.T) {
 	}
 }
 
-// func TestNewSystemInfo(t *testing.T) {
-// 	tests := []struct {
-// 		name string
-// 	}{
-// 		{
-// 			name: "test1",
-// 		},
-// 	}
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			tempDir := t.TempDir()
-// 			testSystemInfo := SystemInfo{
-// 				Os:               runtime.GOOS,
-// 				Arch:             runtime.GOARCH,
-// 				StewPath:         tempDir,
-// 				StewBinPath:      filepath.Join(tempDir, "bin"),
-// 				StewPkgPath:      filepath.Join(tempDir, "pkg"),
-// 				StewLockFilePath: filepath.Join(tempDir, "Stewfile.lock.json"),
-// 				StewTmpPath:      filepath.Join(tempDir, "tmp"),
-// 			}
+func TestNewSystemInfo(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "test1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
 
-// 			got := NewSystemInfo(tempDir)
-// 			if !reflect.DeepEqual(got, testSystemInfo) {
-// 				t.Errorf("NewSystemInfo() = %v, want %v", got, testSystemInfo)
-// 			}
-// 		})
-// 	}
-// }
+			testStewConfig := StewConfig{
+				StewPath:    tempDir,
+				StewBinPath: filepath.Join(tempDir, "bin"),
+			}
+
+			testSystemInfo := SystemInfo{
+				StewPath:         tempDir,
+				StewBinPath:      filepath.Join(tempDir, "bin"),
+				StewPkgPath:      filepath.Join(tempDir, "pkg"),
+				StewLockFilePath: filepath.Join(tempDir, "Stewfile.lock.json"),
+				StewTmpPath:      filepath.Join(tempDir, "tmp"),
+			}
+
+			got := NewSystemInfo(testStewConfig)
+			if !reflect.DeepEqual(got, testSystemInfo) {
+				t.Errorf("NewSystemInfo() = %v, want %v", got, testSystemInfo)
+			}
+		})
+	}
+}
 
 func TestDeleteAssetAndBinary(t *testing.T) {
 	tests := []struct {

--- a/lib/stewfile_test.go
+++ b/lib/stewfile_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"testing"
 )
 
@@ -294,34 +293,34 @@ func TestNewLockFileDoesntExist(t *testing.T) {
 	}
 }
 
-func TestNewSystemInfo(t *testing.T) {
-	tests := []struct {
-		name string
-	}{
-		{
-			name: "test1",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tempDir := t.TempDir()
-			testSystemInfo := SystemInfo{
-				Os:               runtime.GOOS,
-				Arch:             runtime.GOARCH,
-				StewPath:         tempDir,
-				StewBinPath:      filepath.Join(tempDir, "bin"),
-				StewPkgPath:      filepath.Join(tempDir, "pkg"),
-				StewLockFilePath: filepath.Join(tempDir, "Stewfile.lock.json"),
-				StewTmpPath:      filepath.Join(tempDir, "tmp"),
-			}
+// func TestNewSystemInfo(t *testing.T) {
+// 	tests := []struct {
+// 		name string
+// 	}{
+// 		{
+// 			name: "test1",
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			tempDir := t.TempDir()
+// 			testSystemInfo := SystemInfo{
+// 				Os:               runtime.GOOS,
+// 				Arch:             runtime.GOARCH,
+// 				StewPath:         tempDir,
+// 				StewBinPath:      filepath.Join(tempDir, "bin"),
+// 				StewPkgPath:      filepath.Join(tempDir, "pkg"),
+// 				StewLockFilePath: filepath.Join(tempDir, "Stewfile.lock.json"),
+// 				StewTmpPath:      filepath.Join(tempDir, "tmp"),
+// 			}
 
-			got := NewSystemInfo(tempDir)
-			if !reflect.DeepEqual(got, testSystemInfo) {
-				t.Errorf("NewSystemInfo() = %v, want %v", got, testSystemInfo)
-			}
-		})
-	}
-}
+// 			got := NewSystemInfo(tempDir)
+// 			if !reflect.DeepEqual(got, testSystemInfo) {
+// 				t.Errorf("NewSystemInfo() = %v, want %v", got, testSystemInfo)
+// 			}
+// 		})
+// 	}
+// }
 
 func TestDeleteAssetAndBinary(t *testing.T) {
 	tests := []struct {

--- a/lib/ui.go
+++ b/lib/ui.go
@@ -21,6 +21,23 @@ func PromptSelect(message string, options []string) (string, error) {
 	return result, nil
 }
 
+// PromptInput launches the input UI
+func PromptInput(message string, defaultInput string) (string, error) {
+	result := ""
+	prompt := &survey.Input{
+		Message: message,
+		Default: defaultInput,
+	}
+	err := survey.AskOne(prompt, &result, survey.WithIcons(func(icons *survey.IconSet) {
+		icons.Question.Text = "*"
+	}))
+	if err != nil {
+		return "", ExitUserSelectionError{Err: err}
+	}
+
+	return result, nil
+}
+
 // WarningPromptSelect launches the selection UI with a warning styling
 func WarningPromptSelect(message string, options []string) (string, error) {
 	result := ""

--- a/lib/util.go
+++ b/lib/util.go
@@ -377,3 +377,17 @@ func PromptRenameBinary(originalBinaryName string) (string, error) {
 	}
 	return renamedBinaryName, nil
 }
+
+// ResolveTilde will resolve the full path for an input path beginning with ~
+func ResolveTilde(filePath string) (string, error) {
+	if strings.HasPrefix(filePath, "~") {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+
+		return filepath.Join(homeDir, filePath[2:]), nil
+	}
+
+	return filePath, nil
+}

--- a/lib/util.go
+++ b/lib/util.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
 
 	"github.com/marwanhawari/stew/constants"
@@ -39,12 +38,6 @@ func isExecutableFile(filePath string) (bool, error) {
 func CatchAndExit(err error) {
 	if err != nil {
 		fmt.Println(err)
-		stewPath, _ := GetStewPath()
-		stewTmpPath := filepath.Join(stewPath, "tmp")
-		err = os.RemoveAll(stewTmpPath)
-		if err != nil {
-			fmt.Println(err)
-		}
 		os.Exit(1)
 	}
 }
@@ -61,25 +54,6 @@ func PathExists(path string) (bool, error) {
 	}
 
 	return true, nil
-}
-
-// GetStewPath will return the path to the top-level stew directory
-func GetStewPath() (string, error) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-
-	stewPath := filepath.Join(homeDir, ".stew")
-
-	exists, err := PathExists(stewPath)
-	if err != nil {
-		return "", err
-	} else if !exists {
-		return "", StewpathNotFoundError{StewPath: stewPath}
-	}
-
-	return stewPath, nil
 }
 
 // DownloadFile will download a file from url to a given path
@@ -290,14 +264,6 @@ func Contains(slice []string, target string) (int, bool) {
 		}
 	}
 	return -1, false
-}
-
-func getOS() string {
-	return runtime.GOOS
-}
-
-func getArch() string {
-	return runtime.GOARCH
 }
 
 func extractBinary(downloadedFilePath, tmpExtractionPath string) error {

--- a/lib/util_test.go
+++ b/lib/util_test.go
@@ -137,41 +137,6 @@ func TestPathExists(t *testing.T) {
 	}
 }
 
-// func TestGetStewPath(t *testing.T) {
-// 	tests := []struct {
-// 		name    string
-// 		wantErr bool
-// 	}{
-// 		{
-// 			name:    "test1",
-// 			wantErr: false,
-// 		},
-// 	}
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			homeDir, _ := os.UserHomeDir()
-// 			testStewPath := filepath.Join(homeDir, ".stew")
-// 			stewPathExists, _ := PathExists(testStewPath)
-// 			if !stewPathExists {
-// 				os.MkdirAll(testStewPath, 0755)
-// 			}
-
-// 			got, err := GetStewPath()
-// 			if !stewPathExists {
-// 				os.RemoveAll(testStewPath)
-// 			}
-
-// 			if (err != nil) != tt.wantErr {
-// 				t.Errorf("GetStewPath() error = %v, wantErr %v", err, tt.wantErr)
-// 				return
-// 			}
-// 			if got != testStewPath {
-// 				t.Errorf("GetStewPath() = %v, want %v", got, testStewPath)
-// 			}
-// 		})
-// 	}
-// }
-
 func TestDownloadFile(t *testing.T) {
 	type args struct {
 		url string
@@ -681,120 +646,130 @@ func Test_extractBinary(t *testing.T) {
 	}
 }
 
-// func TestInstallBinary(t *testing.T) {
-// 	tests := []struct {
-// 		name    string
-// 		want    string
-// 		wantErr bool
-// 	}{
-// 		{
-// 			name:    "test1",
-// 			want:    "ppath",
-// 			wantErr: false,
-// 		},
-// 	}
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			tempDir := t.TempDir()
-// 			stewPath := filepath.Join(tempDir, ".stew")
+func TestInstallBinary(t *testing.T) {
+	tests := []struct {
+		name    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "test1",
+			want:    "ppath",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
 
-// 			repo := "ppath"
-// 			systemInfo := NewSystemInfo(stewPath)
-// 			os.MkdirAll(systemInfo.StewBinPath, 0755)
-// 			os.MkdirAll(systemInfo.StewPkgPath, 0755)
-// 			os.MkdirAll(systemInfo.StewTmpPath, 0755)
+			repo := "ppath"
 
-// 			lockFile := LockFile{
-// 				Os:   "darwin",
-// 				Arch: "arm64",
-// 				Packages: []PackageData{
-// 					{
-// 						Source: "github",
-// 						Owner:  "marwanhawari",
-// 						Repo:   "ppath",
-// 						Tag:    "v0.0.3",
-// 						Asset:  "ppath-v0.0.3-darwin-arm64.tar.gz",
-// 						Binary: "ppath",
-// 						URL:    "https://github.com/marwanhawari/ppath/releases/download/v0.0.3/ppath-v0.0.3-darwin-arm64.tar.gz",
-// 					},
-// 				},
-// 			}
+			testStewConfig := StewConfig{
+				StewPath:    tempDir,
+				StewBinPath: filepath.Join(tempDir, "bin"),
+			}
 
-// 			downloadedFilePath := filepath.Join(systemInfo.StewPkgPath, "ppath-v0.0.3-darwin-arm64.tar.gz")
-// 			err := DownloadFile(downloadedFilePath, "https://github.com/marwanhawari/ppath/releases/download/v0.0.3/ppath-v0.0.3-darwin-arm64.tar.gz")
+			systemInfo := NewSystemInfo(testStewConfig)
+			os.MkdirAll(systemInfo.StewBinPath, 0755)
+			os.MkdirAll(systemInfo.StewPkgPath, 0755)
+			os.MkdirAll(systemInfo.StewTmpPath, 0755)
 
-// 			if err != nil {
-// 				t.Errorf("Could not download file to %v", downloadedFilePath)
-// 			}
+			lockFile := LockFile{
+				Os:   "darwin",
+				Arch: "arm64",
+				Packages: []PackageData{
+					{
+						Source: "github",
+						Owner:  "marwanhawari",
+						Repo:   "ppath",
+						Tag:    "v0.0.3",
+						Asset:  "ppath-v0.0.3-darwin-arm64.tar.gz",
+						Binary: "ppath",
+						URL:    "https://github.com/marwanhawari/ppath/releases/download/v0.0.3/ppath-v0.0.3-darwin-arm64.tar.gz",
+					},
+				},
+			}
 
-// 			got, err := InstallBinary(downloadedFilePath, repo, systemInfo, &lockFile, true)
-// 			if (err != nil) != tt.wantErr {
-// 				t.Errorf("InstallBinary() error = %v, wantErr %v", err, tt.wantErr)
-// 				return
-// 			}
-// 			if got != tt.want {
-// 				t.Errorf("InstallBinary() = %v, want %v", got, tt.want)
-// 			}
+			downloadedFilePath := filepath.Join(systemInfo.StewPkgPath, "ppath-v0.0.3-darwin-arm64.tar.gz")
+			err := DownloadFile(downloadedFilePath, "https://github.com/marwanhawari/ppath/releases/download/v0.0.3/ppath-v0.0.3-darwin-arm64.tar.gz")
 
-// 		})
-// 	}
-// }
+			if err != nil {
+				t.Errorf("Could not download file to %v", downloadedFilePath)
+			}
 
-// func TestInstallBinary_Fail(t *testing.T) {
-// 	tests := []struct {
-// 		name    string
-// 		want    string
-// 		wantErr bool
-// 	}{
-// 		{
-// 			name:    "test1",
-// 			want:    "",
-// 			wantErr: true,
-// 		},
-// 	}
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			tempDir := t.TempDir()
-// 			stewPath := filepath.Join(tempDir, ".stew")
+			got, err := InstallBinary(downloadedFilePath, repo, systemInfo, &lockFile, true)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("InstallBinary() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("InstallBinary() = %v, want %v", got, tt.want)
+			}
 
-// 			repo := "ppath"
-// 			systemInfo := NewSystemInfo(stewPath)
-// 			os.MkdirAll(systemInfo.StewBinPath, 0755)
-// 			os.MkdirAll(systemInfo.StewPkgPath, 0755)
-// 			os.MkdirAll(systemInfo.StewTmpPath, 0755)
+		})
+	}
+}
 
-// 			lockFile := LockFile{
-// 				Os:   "darwin",
-// 				Arch: "arm64",
-// 				Packages: []PackageData{
-// 					{
-// 						Source: "github",
-// 						Owner:  "marwanhawari",
-// 						Repo:   "ppath",
-// 						Tag:    "v0.0.3",
-// 						Asset:  "ppath-v0.0.3-darwin-arm64.tar.gz",
-// 						Binary: "ppath",
-// 						URL:    "https://github.com/marwanhawari/ppath/releases/download/v0.0.3/ppath-v0.0.3-darwin-arm64.tar.gz",
-// 					},
-// 				},
-// 			}
+func TestInstallBinary_Fail(t *testing.T) {
+	tests := []struct {
+		name    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "test1",
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
 
-// 			downloadedFilePath := filepath.Join(systemInfo.StewPkgPath, "ppath-v0.0.3-darwin-arm64.tar.gz")
-// 			err := DownloadFile(downloadedFilePath, "https://github.com/marwanhawari/ppath/releases/download/v0.0.3/ppath-v0.0.3-darwin-arm64.tar.gz")
+			repo := "ppath"
 
-// 			if err != nil {
-// 				t.Errorf("Could not download file to %v", downloadedFilePath)
-// 			}
+			testStewConfig := StewConfig{
+				StewPath:    tempDir,
+				StewBinPath: filepath.Join(tempDir, "bin"),
+			}
 
-// 			got, err := InstallBinary(downloadedFilePath, repo, systemInfo, &lockFile, false)
-// 			if (err != nil) != tt.wantErr {
-// 				t.Errorf("InstallBinary() error = %v, wantErr %v", err, tt.wantErr)
-// 				return
-// 			}
-// 			if got != tt.want {
-// 				t.Errorf("InstallBinary() = %v, want %v", got, tt.want)
-// 			}
+			systemInfo := NewSystemInfo(testStewConfig)
+			os.MkdirAll(systemInfo.StewBinPath, 0755)
+			os.MkdirAll(systemInfo.StewPkgPath, 0755)
+			os.MkdirAll(systemInfo.StewTmpPath, 0755)
 
-// 		})
-// 	}
-// }
+			lockFile := LockFile{
+				Os:   "darwin",
+				Arch: "arm64",
+				Packages: []PackageData{
+					{
+						Source: "github",
+						Owner:  "marwanhawari",
+						Repo:   "ppath",
+						Tag:    "v0.0.3",
+						Asset:  "ppath-v0.0.3-darwin-arm64.tar.gz",
+						Binary: "ppath",
+						URL:    "https://github.com/marwanhawari/ppath/releases/download/v0.0.3/ppath-v0.0.3-darwin-arm64.tar.gz",
+					},
+				},
+			}
+
+			downloadedFilePath := filepath.Join(systemInfo.StewPkgPath, "ppath-v0.0.3-darwin-arm64.tar.gz")
+			err := DownloadFile(downloadedFilePath, "https://github.com/marwanhawari/ppath/releases/download/v0.0.3/ppath-v0.0.3-darwin-arm64.tar.gz")
+
+			if err != nil {
+				t.Errorf("Could not download file to %v", downloadedFilePath)
+			}
+
+			got, err := InstallBinary(downloadedFilePath, repo, systemInfo, &lockFile, false)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("InstallBinary() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("InstallBinary() = %v, want %v", got, tt.want)
+			}
+
+		})
+	}
+}

--- a/lib/util_test.go
+++ b/lib/util_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"testing"
 )
 
@@ -138,40 +137,40 @@ func TestPathExists(t *testing.T) {
 	}
 }
 
-func TestGetStewPath(t *testing.T) {
-	tests := []struct {
-		name    string
-		wantErr bool
-	}{
-		{
-			name:    "test1",
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			homeDir, _ := os.UserHomeDir()
-			testStewPath := filepath.Join(homeDir, ".stew")
-			stewPathExists, _ := PathExists(testStewPath)
-			if !stewPathExists {
-				os.MkdirAll(testStewPath, 0755)
-			}
+// func TestGetStewPath(t *testing.T) {
+// 	tests := []struct {
+// 		name    string
+// 		wantErr bool
+// 	}{
+// 		{
+// 			name:    "test1",
+// 			wantErr: false,
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			homeDir, _ := os.UserHomeDir()
+// 			testStewPath := filepath.Join(homeDir, ".stew")
+// 			stewPathExists, _ := PathExists(testStewPath)
+// 			if !stewPathExists {
+// 				os.MkdirAll(testStewPath, 0755)
+// 			}
 
-			got, err := GetStewPath()
-			if !stewPathExists {
-				os.RemoveAll(testStewPath)
-			}
+// 			got, err := GetStewPath()
+// 			if !stewPathExists {
+// 				os.RemoveAll(testStewPath)
+// 			}
 
-			if (err != nil) != tt.wantErr {
-				t.Errorf("GetStewPath() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != testStewPath {
-				t.Errorf("GetStewPath() = %v, want %v", got, testStewPath)
-			}
-		})
-	}
-}
+// 			if (err != nil) != tt.wantErr {
+// 				t.Errorf("GetStewPath() error = %v, wantErr %v", err, tt.wantErr)
+// 				return
+// 			}
+// 			if got != testStewPath {
+// 				t.Errorf("GetStewPath() = %v, want %v", got, testStewPath)
+// 			}
+// 		})
+// 	}
+// }
 
 func TestDownloadFile(t *testing.T) {
 	type args struct {
@@ -650,44 +649,6 @@ func TestContains(t *testing.T) {
 	}
 }
 
-func Test_getOS(t *testing.T) {
-	tests := []struct {
-		name string
-		want string
-	}{
-		{
-			name: "test1",
-			want: runtime.GOOS,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := getOS(); got != tt.want {
-				t.Errorf("getOS() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_getArch(t *testing.T) {
-	tests := []struct {
-		name string
-		want string
-	}{
-		{
-			name: "test1",
-			want: runtime.GOARCH,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := getArch(); got != tt.want {
-				t.Errorf("getArch() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func Test_extractBinary(t *testing.T) {
 	type args struct {
 		downloadedFilePath string
@@ -720,120 +681,120 @@ func Test_extractBinary(t *testing.T) {
 	}
 }
 
-func TestInstallBinary(t *testing.T) {
-	tests := []struct {
-		name    string
-		want    string
-		wantErr bool
-	}{
-		{
-			name:    "test1",
-			want:    "ppath",
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tempDir := t.TempDir()
-			stewPath := filepath.Join(tempDir, ".stew")
+// func TestInstallBinary(t *testing.T) {
+// 	tests := []struct {
+// 		name    string
+// 		want    string
+// 		wantErr bool
+// 	}{
+// 		{
+// 			name:    "test1",
+// 			want:    "ppath",
+// 			wantErr: false,
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			tempDir := t.TempDir()
+// 			stewPath := filepath.Join(tempDir, ".stew")
 
-			repo := "ppath"
-			systemInfo := NewSystemInfo(stewPath)
-			os.MkdirAll(systemInfo.StewBinPath, 0755)
-			os.MkdirAll(systemInfo.StewPkgPath, 0755)
-			os.MkdirAll(systemInfo.StewTmpPath, 0755)
+// 			repo := "ppath"
+// 			systemInfo := NewSystemInfo(stewPath)
+// 			os.MkdirAll(systemInfo.StewBinPath, 0755)
+// 			os.MkdirAll(systemInfo.StewPkgPath, 0755)
+// 			os.MkdirAll(systemInfo.StewTmpPath, 0755)
 
-			lockFile := LockFile{
-				Os:   "darwin",
-				Arch: "arm64",
-				Packages: []PackageData{
-					{
-						Source: "github",
-						Owner:  "marwanhawari",
-						Repo:   "ppath",
-						Tag:    "v0.0.3",
-						Asset:  "ppath-v0.0.3-darwin-arm64.tar.gz",
-						Binary: "ppath",
-						URL:    "https://github.com/marwanhawari/ppath/releases/download/v0.0.3/ppath-v0.0.3-darwin-arm64.tar.gz",
-					},
-				},
-			}
+// 			lockFile := LockFile{
+// 				Os:   "darwin",
+// 				Arch: "arm64",
+// 				Packages: []PackageData{
+// 					{
+// 						Source: "github",
+// 						Owner:  "marwanhawari",
+// 						Repo:   "ppath",
+// 						Tag:    "v0.0.3",
+// 						Asset:  "ppath-v0.0.3-darwin-arm64.tar.gz",
+// 						Binary: "ppath",
+// 						URL:    "https://github.com/marwanhawari/ppath/releases/download/v0.0.3/ppath-v0.0.3-darwin-arm64.tar.gz",
+// 					},
+// 				},
+// 			}
 
-			downloadedFilePath := filepath.Join(systemInfo.StewPkgPath, "ppath-v0.0.3-darwin-arm64.tar.gz")
-			err := DownloadFile(downloadedFilePath, "https://github.com/marwanhawari/ppath/releases/download/v0.0.3/ppath-v0.0.3-darwin-arm64.tar.gz")
+// 			downloadedFilePath := filepath.Join(systemInfo.StewPkgPath, "ppath-v0.0.3-darwin-arm64.tar.gz")
+// 			err := DownloadFile(downloadedFilePath, "https://github.com/marwanhawari/ppath/releases/download/v0.0.3/ppath-v0.0.3-darwin-arm64.tar.gz")
 
-			if err != nil {
-				t.Errorf("Could not download file to %v", downloadedFilePath)
-			}
+// 			if err != nil {
+// 				t.Errorf("Could not download file to %v", downloadedFilePath)
+// 			}
 
-			got, err := InstallBinary(downloadedFilePath, repo, systemInfo, &lockFile, true)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("InstallBinary() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("InstallBinary() = %v, want %v", got, tt.want)
-			}
+// 			got, err := InstallBinary(downloadedFilePath, repo, systemInfo, &lockFile, true)
+// 			if (err != nil) != tt.wantErr {
+// 				t.Errorf("InstallBinary() error = %v, wantErr %v", err, tt.wantErr)
+// 				return
+// 			}
+// 			if got != tt.want {
+// 				t.Errorf("InstallBinary() = %v, want %v", got, tt.want)
+// 			}
 
-		})
-	}
-}
+// 		})
+// 	}
+// }
 
-func TestInstallBinary_Fail(t *testing.T) {
-	tests := []struct {
-		name    string
-		want    string
-		wantErr bool
-	}{
-		{
-			name:    "test1",
-			want:    "",
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tempDir := t.TempDir()
-			stewPath := filepath.Join(tempDir, ".stew")
+// func TestInstallBinary_Fail(t *testing.T) {
+// 	tests := []struct {
+// 		name    string
+// 		want    string
+// 		wantErr bool
+// 	}{
+// 		{
+// 			name:    "test1",
+// 			want:    "",
+// 			wantErr: true,
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			tempDir := t.TempDir()
+// 			stewPath := filepath.Join(tempDir, ".stew")
 
-			repo := "ppath"
-			systemInfo := NewSystemInfo(stewPath)
-			os.MkdirAll(systemInfo.StewBinPath, 0755)
-			os.MkdirAll(systemInfo.StewPkgPath, 0755)
-			os.MkdirAll(systemInfo.StewTmpPath, 0755)
+// 			repo := "ppath"
+// 			systemInfo := NewSystemInfo(stewPath)
+// 			os.MkdirAll(systemInfo.StewBinPath, 0755)
+// 			os.MkdirAll(systemInfo.StewPkgPath, 0755)
+// 			os.MkdirAll(systemInfo.StewTmpPath, 0755)
 
-			lockFile := LockFile{
-				Os:   "darwin",
-				Arch: "arm64",
-				Packages: []PackageData{
-					{
-						Source: "github",
-						Owner:  "marwanhawari",
-						Repo:   "ppath",
-						Tag:    "v0.0.3",
-						Asset:  "ppath-v0.0.3-darwin-arm64.tar.gz",
-						Binary: "ppath",
-						URL:    "https://github.com/marwanhawari/ppath/releases/download/v0.0.3/ppath-v0.0.3-darwin-arm64.tar.gz",
-					},
-				},
-			}
+// 			lockFile := LockFile{
+// 				Os:   "darwin",
+// 				Arch: "arm64",
+// 				Packages: []PackageData{
+// 					{
+// 						Source: "github",
+// 						Owner:  "marwanhawari",
+// 						Repo:   "ppath",
+// 						Tag:    "v0.0.3",
+// 						Asset:  "ppath-v0.0.3-darwin-arm64.tar.gz",
+// 						Binary: "ppath",
+// 						URL:    "https://github.com/marwanhawari/ppath/releases/download/v0.0.3/ppath-v0.0.3-darwin-arm64.tar.gz",
+// 					},
+// 				},
+// 			}
 
-			downloadedFilePath := filepath.Join(systemInfo.StewPkgPath, "ppath-v0.0.3-darwin-arm64.tar.gz")
-			err := DownloadFile(downloadedFilePath, "https://github.com/marwanhawari/ppath/releases/download/v0.0.3/ppath-v0.0.3-darwin-arm64.tar.gz")
+// 			downloadedFilePath := filepath.Join(systemInfo.StewPkgPath, "ppath-v0.0.3-darwin-arm64.tar.gz")
+// 			err := DownloadFile(downloadedFilePath, "https://github.com/marwanhawari/ppath/releases/download/v0.0.3/ppath-v0.0.3-darwin-arm64.tar.gz")
 
-			if err != nil {
-				t.Errorf("Could not download file to %v", downloadedFilePath)
-			}
+// 			if err != nil {
+// 				t.Errorf("Could not download file to %v", downloadedFilePath)
+// 			}
 
-			got, err := InstallBinary(downloadedFilePath, repo, systemInfo, &lockFile, false)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("InstallBinary() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("InstallBinary() = %v, want %v", got, tt.want)
-			}
+// 			got, err := InstallBinary(downloadedFilePath, repo, systemInfo, &lockFile, false)
+// 			if (err != nil) != tt.wantErr {
+// 				t.Errorf("InstallBinary() error = %v, wantErr %v", err, tt.wantErr)
+// 				return
+// 			}
+// 			if got != tt.want {
+// 				t.Errorf("InstallBinary() = %v, want %v", got, tt.want)
+// 			}
 
-		})
-	}
-}
+// 		})
+// 	}
+// }

--- a/main.go
+++ b/main.go
@@ -73,7 +73,7 @@ func main() {
 			},
 			{
 				Name:    "rename",
-				Usage:   "Rename an installed binary using a prompt UI. [Ex: stew rename fzf]",
+				Usage:   "Rename an installed binary using an interactive UI. [Ex: stew rename fzf]",
 				Aliases: []string{"re"},
 				Action: func(c *cli.Context) error {
 					cmd.Rename(c.Args().First())
@@ -96,6 +96,14 @@ func main() {
 				},
 				Action: func(c *cli.Context) error {
 					cmd.List(c.Bool("tags"), c.Bool("assets"))
+					return nil
+				},
+			},
+			{
+				Name:  "config",
+				Usage: "Configure the stew file paths using an interactive UI. [Ex: stew config]",
+				Action: func(c *cli.Context) error {
+					cmd.Config()
 					return nil
 				},
 			},


### PR DESCRIPTION
This PR introduces the ability for users to configure the `stewPath` (which is where `stew` data is stored - originally hardcoded as `~/.stew`) and the `stewBinPath` (which is where binaries are actually installed - originally harcoded as `~/.stew/bin`). There are 3 ways to configure these:
1. Upon initial installation with the `install.sh` script, it will prompt you to configure these.
2. If you install the `stew` binary without the `install.sh` script or later realize you want to change them, you can use the new `stew config` subcommand.
3. You can manually edit the stew config file (`$XDG_CONFIG_HOME/config.json` or `~/.config/stew/config.json` on Linux/macOS and `~/AppData/Local/stew/Config/config.json` on Windows)

Additionally, the new default locations for `stewPath` and `stewBinPath` follow the XDG spec:

|                    | Linux/macOS | Windows |
| ------------ | ------------ | ---------- |
| `stewPath` | `$XDG_DATA_HOME/stew` or `~/.local/share/stew` | `~/AppData/Local/stew` |
| `stewBinPath` | `$XDG_DATA_HOME/stew/bin` or `~/.local/share/stew/bin` | `~/AppData/Local/stew/bin` |