### PR TITLE
upgrade go from 1.17 to 1.22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.17]
+        go-version: [1.22]
 
     steps:
     - uses: actions/checkout@v2
@@ -44,7 +44,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.22
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: test
 on:
   push:
     branches:
-      - '**'
+      - main
     tags-ignore:
       - v*
   pull_request:
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.17]
+        go-version: [1.22]
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Stew binary
+stew
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/marwanhawari/stew
 
-go 1.17
+go 1.22
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.2


### PR DESCRIPTION
Upgrade the go version. This opens the door for using generics (introduced in go 1.18).