### PR TITLE
fix: don't throw error for if trying to upgrade a package and the asset has the same name

### DIFF
--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -56,16 +56,9 @@ func Browse(cliInput string) {
 
 	downloadURL := githubProject.Releases[tagIndex].Assets[assetIndex].DownloadURL
 	downloadPath := filepath.Join(stewPkgPath, asset)
-	downloadPathExists, err := stew.PathExists(downloadPath)
+	err = stew.DownloadFile(downloadPath, downloadURL)
 	stew.CatchAndExit(err)
-
-	if downloadPathExists {
-		stew.CatchAndExit(stew.AssetAlreadyDownloadedError{Asset: asset})
-	} else {
-		err = stew.DownloadFile(downloadPath, downloadURL)
-		stew.CatchAndExit(err)
-		fmt.Printf("✅ Downloaded %v to %v\n", constants.GreenColor(asset), constants.GreenColor(stewPkgPath))
-	}
+	fmt.Printf("✅ Downloaded %v to %v\n", constants.GreenColor(asset), constants.GreenColor(stewPkgPath))
 
 	binaryName, err := stew.InstallBinary(downloadPath, repo, systemInfo, &lockFile, false)
 	if err != nil {

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -107,16 +107,9 @@ func Install(cliInputs []string) {
 		}
 
 		downloadPath := filepath.Join(stewPkgPath, asset)
-		downloadPathExists, err := stew.PathExists(downloadPath)
+		err = stew.DownloadFile(downloadPath, downloadURL)
 		stew.CatchAndExit(err)
-		if downloadPathExists {
-			fmt.Fprintln(os.Stderr, stew.AssetAlreadyDownloadedError{Asset: asset})
-			continue
-		} else {
-			err = stew.DownloadFile(downloadPath, downloadURL)
-			stew.CatchAndExit(err)
-			fmt.Printf("✅ Downloaded %v to %v\n", constants.GreenColor(asset), constants.GreenColor(stewPkgPath))
-		}
+		fmt.Printf("✅ Downloaded %v to %v\n", constants.GreenColor(asset), constants.GreenColor(stewPkgPath))
 
 		binaryName, err := stew.InstallBinary(downloadPath, repo, systemInfo, &lockFile, false)
 		if err != nil {

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -110,7 +110,7 @@ func Install(cliInputs []string) {
 		downloadPathExists, err := stew.PathExists(downloadPath)
 		stew.CatchAndExit(err)
 		if downloadPathExists {
-			fmt.Println(stew.AssetAlreadyDownloadedError{Asset: asset})
+			fmt.Fprintln(os.Stderr, stew.AssetAlreadyDownloadedError{Asset: asset})
 			continue
 		} else {
 			err = stew.DownloadFile(downloadPath, downloadURL)

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -10,14 +10,14 @@ import (
 )
 
 // Upgrade is executed when you run `stew upgrade`
-func Upgrade(cliFlag bool, binaryName string) {
+func Upgrade(upgradeAllCliFlag bool, binaryName string) {
 
 	userOS, userArch, _, systemInfo, err := stew.Initialize()
 	stew.CatchAndExit(err)
 
-	if cliFlag && binaryName != "" {
+	if upgradeAllCliFlag && binaryName != "" {
 		stew.CatchAndExit(stew.CLIFlagAndInputError{})
-	} else if !cliFlag {
+	} else if !upgradeAllCliFlag {
 		err := stew.ValidateCLIInput(binaryName)
 		stew.CatchAndExit(err)
 	}
@@ -42,7 +42,7 @@ func Upgrade(cliFlag bool, binaryName string) {
 
 	var binaryFound bool
 	for index, pkg := range lockFile.Packages {
-		shouldUpgradePackage := (cliFlag || pkg.Binary == binaryName)
+		shouldUpgradePackage := (upgradeAllCliFlag || pkg.Binary == binaryName)
 		if !shouldUpgradePackage {
 			continue
 		}
@@ -110,7 +110,7 @@ func Upgrade(cliFlag bool, binaryName string) {
 
 		fmt.Printf("✨ Successfully upgraded the %v binary from %v to %v\n", constants.GreenColor(pkg.Binary), constants.GreenColor(pkg.Tag), constants.GreenColor(tag))
 	}
-	if !cliFlag && !binaryFound {
+	if !upgradeAllCliFlag && !binaryFound {
 		stew.CatchAndExit(stew.BinaryNotInstalledError{Binary: binaryName})
 	}
 }

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -50,7 +50,7 @@ func Upgrade(cliFlag bool, binaryName string) {
 		binaryFound = true
 
 		if pkg.Source == "other" {
-			fmt.Println(stew.InstalledFromURLError{Binary: pkg.Binary})
+			fmt.Fprintln(os.Stderr, stew.InstalledFromURLError{Binary: pkg.Binary})
 			continue
 		}
 		owner := pkg.Owner
@@ -70,7 +70,7 @@ func Upgrade(cliFlag bool, binaryName string) {
 		tag := githubProject.Releases[tagIndex].TagName
 
 		if pkg.Tag == tag {
-			fmt.Println(stew.AlreadyInstalledLatestTagError{Tag: tag})
+			fmt.Fprintln(os.Stderr, stew.AlreadyInstalledLatestTagError{Tag: tag})
 			continue
 		}
 

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -22,9 +22,6 @@ func Upgrade(upgradeAllCliFlag bool, binaryName string) {
 		stew.CatchAndExit(err)
 	}
 
-	sp := constants.LoadingSpinner
-
-	stewPkgPath := systemInfo.StewPkgPath
 	stewTmpPath := systemInfo.StewTmpPath
 	stewLockFilePath := systemInfo.StewLockFilePath
 
@@ -40,77 +37,95 @@ func Upgrade(upgradeAllCliFlag bool, binaryName string) {
 		stew.CatchAndExit(stew.NoBinariesInstalledError{})
 	}
 
-	var binaryFound bool
-	for index, pkg := range lockFile.Packages {
-		shouldUpgradePackage := (upgradeAllCliFlag || pkg.Binary == binaryName)
-		if !shouldUpgradePackage {
-			continue
-		}
-		fmt.Println(constants.GreenColor(pkg.Binary))
-		binaryFound = true
-
-		if pkg.Source == "other" {
-			fmt.Fprintln(os.Stderr, stew.InstalledFromURLError{Binary: pkg.Binary})
-			continue
-		}
-		owner := pkg.Owner
-		repo := pkg.Repo
-
-		sp.Start()
-		githubProject, err := stew.NewGithubProject(owner, repo)
-		sp.Stop()
+	if upgradeAllCliFlag {
+		upgradeAll(userOS, userArch, lockFile, systemInfo)
+	} else {
+		err := upgradeOne(binaryName, userOS, userArch, lockFile, systemInfo)
 		stew.CatchAndExit(err)
-
-		// This will make sure that there are any tags at all
-		_, err = stew.GetGithubReleasesTags(githubProject)
-		stew.CatchAndExit(err)
-
-		// Get the latest tag
-		tagIndex := 0
-		tag := githubProject.Releases[tagIndex].TagName
-
-		if pkg.Tag == tag {
-			fmt.Fprintln(os.Stderr, stew.AlreadyInstalledLatestTagError{Tag: tag})
-			continue
-		}
-
-		// Make sure there are any assets at all
-		releaseAssets, err := stew.GetGithubReleasesAssets(githubProject, tag)
-		stew.CatchAndExit(err)
-
-		asset, err := stew.DetectAsset(userOS, userArch, releaseAssets)
-		stew.CatchAndExit(err)
-		assetIndex, _ := stew.Contains(releaseAssets, asset)
-
-		downloadURL := githubProject.Releases[tagIndex].Assets[assetIndex].DownloadURL
-
-		downloadPath := filepath.Join(stewPkgPath, asset)
-		downloadPathExists, err := stew.PathExists(downloadPath)
-		stew.CatchAndExit(err)
-		if downloadPathExists {
-			stew.CatchAndExit(stew.AssetAlreadyDownloadedError{Asset: asset})
-		} else {
-			err = stew.DownloadFile(downloadPath, downloadURL)
-			stew.CatchAndExit(err)
-			fmt.Printf("✅ Downloaded %v to %v\n", constants.GreenColor(asset), constants.GreenColor(stewPkgPath))
-		}
-
-		_, err = stew.InstallBinary(downloadPath, repo, systemInfo, &lockFile, true)
-		if err != nil {
-			os.RemoveAll(downloadPath)
-			stew.CatchAndExit(err)
-		}
-
-		lockFile.Packages[index].Tag = tag
-		lockFile.Packages[index].Asset = asset
-		lockFile.Packages[index].URL = downloadURL
-
-		err = stew.WriteLockFileJSON(lockFile, stewLockFilePath)
-		stew.CatchAndExit(err)
-
-		fmt.Printf("✨ Successfully upgraded the %v binary from %v to %v\n", constants.GreenColor(pkg.Binary), constants.GreenColor(pkg.Tag), constants.GreenColor(tag))
 	}
-	if !upgradeAllCliFlag && !binaryFound {
-		stew.CatchAndExit(stew.BinaryNotInstalledError{Binary: binaryName})
+}
+
+func upgradeOne(binaryName, userOS, userArch string, lockFile stew.LockFile, systemInfo stew.SystemInfo) error {
+	sp := constants.LoadingSpinner
+	stewPkgPath := systemInfo.StewPkgPath
+	stewLockFilePath := systemInfo.StewLockFilePath
+
+	indexInLockFile, binaryFoundInLockFile := stew.FindBinaryInLockFile(lockFile, binaryName)
+	if !binaryFoundInLockFile {
+		return stew.BinaryNotInstalledError{Binary: binaryName}
+	}
+
+	pkg := lockFile.Packages[indexInLockFile]
+	fmt.Println(constants.GreenColor(pkg.Binary))
+	if pkg.Source == "other" {
+		return stew.InstalledFromURLError{Binary: pkg.Binary}
+	}
+	owner := pkg.Owner
+	repo := pkg.Repo
+
+	sp.Start()
+	githubProject, err := stew.NewGithubProject(owner, repo)
+	sp.Stop()
+	if err != nil {
+		return err
+	}
+
+	// This will make sure that there are any tags at all
+	_, err = stew.GetGithubReleasesTags(githubProject)
+	if err != nil {
+		return err
+	}
+
+	// Get the latest tag
+	tagIndex := 0
+	tag := githubProject.Releases[tagIndex].TagName
+
+	if pkg.Tag == tag {
+		return stew.AlreadyInstalledLatestTagError{Tag: tag}
+	}
+
+	// Make sure there are any assets at all
+	releaseAssets, err := stew.GetGithubReleasesAssets(githubProject, tag)
+	if err != nil {
+		return err
+	}
+
+	asset, err := stew.DetectAsset(userOS, userArch, releaseAssets)
+	if err != nil {
+		return err
+	}
+	assetIndex, _ := stew.Contains(releaseAssets, asset)
+	downloadURL := githubProject.Releases[tagIndex].Assets[assetIndex].DownloadURL
+	downloadPath := filepath.Join(stewPkgPath, asset)
+	err = stew.DownloadFile(downloadPath, downloadURL)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("✅ Downloaded %v to %v\n", constants.GreenColor(asset), constants.GreenColor(stewPkgPath))
+
+	_, err = stew.InstallBinary(downloadPath, repo, systemInfo, &lockFile, true)
+	if err != nil {
+		if err := os.RemoveAll(downloadPath); err != nil {
+			return err
+		}
+	}
+
+	lockFile.Packages[indexInLockFile].Tag = tag
+	lockFile.Packages[indexInLockFile].Asset = asset
+	lockFile.Packages[indexInLockFile].URL = downloadURL
+	if err := stew.WriteLockFileJSON(lockFile, stewLockFilePath); err != nil {
+		return err
+	}
+
+	fmt.Printf("✨ Successfully upgraded the %v binary from %v to %v\n", constants.GreenColor(pkg.Binary), constants.GreenColor(pkg.Tag), constants.GreenColor(tag))
+	return nil
+}
+
+func upgradeAll(userOS, userArch string, lockFile stew.LockFile, systemInfo stew.SystemInfo) {
+	for _, pkg := range lockFile.Packages {
+		if err := upgradeOne(pkg.Binary, userOS, userArch, lockFile, systemInfo); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			continue
+		}
 	}
 }

--- a/lib/errors.go
+++ b/lib/errors.go
@@ -93,15 +93,6 @@ func (e CLIFlagAndInputError) Error() string {
 	return fmt.Sprintf("%v Cannot use the --all flag with a positional argument", constants.RedColor("Error:"))
 }
 
-// AssetAlreadyDownloadedError occurs if the requested asset has already been downloaded
-type AssetAlreadyDownloadedError struct {
-	Asset string
-}
-
-func (e AssetAlreadyDownloadedError) Error() string {
-	return fmt.Sprintf("%v The %v asset has already been downloaded and installed", constants.RedColor("Error:"), constants.RedColor(e.Asset))
-}
-
 // AbortBinaryOverwriteError occurs if the overwrite of a binary is aborted
 type AbortBinaryOverwriteError struct {
 	Binary string

--- a/lib/errors_test.go
+++ b/lib/errors_test.go
@@ -265,35 +265,6 @@ func TestCLIFlagAndInputError_Error(t *testing.T) {
 	}
 }
 
-func TestAssetAlreadyDownloadedError_Error(t *testing.T) {
-	type fields struct {
-		Asset string
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		want   string
-	}{
-		{
-			name: "test1",
-			fields: fields{
-				Asset: "testAsset",
-			},
-			want: fmt.Sprintf("%v The %v asset has already been downloaded and installed", constants.RedColor("Error:"), constants.RedColor("testAsset")),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			e := AssetAlreadyDownloadedError{
-				Asset: tt.fields.Asset,
-			}
-			if got := e.Error(); got != tt.want {
-				t.Errorf("AssetAlreadyDownloadedError.Error() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestAbortBinaryOverwriteError_Error(t *testing.T) {
 	type fields struct {
 		Binary string

--- a/lib/util.go
+++ b/lib/util.go
@@ -197,7 +197,6 @@ func ValidateCLIInput(cliInput string) error {
 	if cliInput == "" {
 		return EmptyCLIInputError{}
 	}
-
 	return nil
 }
 
@@ -271,7 +270,7 @@ func parseURLInput(cliInput string) (CLIInput, error) {
 }
 
 // Contains checks if a string slice contains a given target
-func Contains(slice []string, target string) (int, bool) {
+func Contains[T comparable](slice []T, target T) (int, bool) {
 	for index, element := range slice {
 		if target == element {
 			return index, true

--- a/lib/util.go
+++ b/lib/util.go
@@ -351,14 +351,16 @@ func handleExistingBinary(lockFile *LockFile, binaryName, newlyDownloadedAssetPa
 			return AbortBinaryOverwriteError{Binary: binaryName}
 		}
 	}
-	return overwriteBinary(lockFile, indexInLockFile, stewPkgPath, overwriteFromUpgrade)
+	return overwriteBinary(lockFile, indexInLockFile, newlyDownloadedAssetPath, stewPkgPath, overwriteFromUpgrade)
 }
 
-func overwriteBinary(lockFile *LockFile, indexInLockFile int, stewPkgPath string, overwriteFromUpgrade bool) error {
+func overwriteBinary(lockFile *LockFile, indexInLockFile int, newlyDownloadedAssetPath, stewPkgPath string, overwriteFromUpgrade bool) error {
 	pkg := lockFile.Packages[indexInLockFile]
 	previousAssetPath := filepath.Join(stewPkgPath, pkg.Asset)
-	if err := os.RemoveAll(previousAssetPath); err != nil {
-		return err
+	if previousAssetPath != newlyDownloadedAssetPath {
+		if err := os.RemoveAll(previousAssetPath); err != nil {
+			return err
+		}
 	}
 	// If not overwriting as part of an upgrade, remove the package entry from the lock file
 	// This is because the upgrade command will update the package entry in place

--- a/lib/util.go
+++ b/lib/util.go
@@ -37,7 +37,7 @@ func isExecutableFile(filePath string) (bool, error) {
 // CatchAndExit will catch errors and immediately exit
 func CatchAndExit(err error) {
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
fixes #17 #19

Additionally:
- started using stderr for errors
- refactor some functions in utils
- fix bug that would delete the new pkg if the old pkg had the same name