### PR TITLE
improve github asset detection

### DIFF
--- a/lib/github.go
+++ b/lib/github.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/marwanhawari/stew/constants"
 )
@@ -122,6 +123,17 @@ func assetsFound(releaseAssets []string, releaseTag string) error {
 	return nil
 }
 
+func filterReleaseAssets(assets []string) []string {
+	var filteredAssets []string
+	for _, asset := range assets {
+		if strings.HasSuffix(asset, ".sha256") {
+			continue
+		}
+		filteredAssets = append(filteredAssets, asset)
+	}
+	return filteredAssets
+}
+
 // DetectAsset will automatically detect a release asset matching your systems OS/arch or prompt you to manually select an asset
 func DetectAsset(userOS string, userArch string, releaseAssets []string) (string, error) {
 	var detectedOSAssets []string
@@ -139,7 +151,8 @@ func DetectAsset(userOS string, userArch string, releaseAssets []string) (string
 		return "", err
 	}
 
-	for _, asset := range releaseAssets {
+	filteredReleaseAssets := filterReleaseAssets(releaseAssets)
+	for _, asset := range filteredReleaseAssets {
 		if reOS.MatchString(asset) {
 			detectedOSAssets = append(detectedOSAssets, asset)
 		}
@@ -176,7 +189,7 @@ func DetectAsset(userOS string, userArch string, releaseAssets []string) (string
 			}
 		}
 		if finalAsset == "" {
-			finalAsset, err = WarningPromptSelect("Could not automatically detect the release asset matching your OS/Arch. Please select it manually:", releaseAssets)
+			finalAsset, err = WarningPromptSelect("Could not automatically detect the release asset matching your OS/Arch. Please select it manually:", filteredReleaseAssets)
 			if err != nil {
 				return "", err
 			}


### PR DESCRIPTION
Often, repos include a corresponding sha256 file for each release asset (such as in https://github.com/dominikh/go-tools/releases). For the purposes of asset detection it can cause the user to have to unnecessarily select the asset manually because the regex doesn't make a distinction between
`staticcheck_darwin_arm64.tar.gz.sha256`
and
`staticcheck_darwin_arm64.tar.gz`

This PR just filters out files that end in `.sha256` so that stew is more likely to automatically detect the appropriate release asset for the user.