### PR TITLE
feat: headless batch install

### DIFF
--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -60,7 +60,7 @@ func Browse(cliInput string) {
 	stew.CatchAndExit(err)
 	fmt.Printf("✅ Downloaded %v to %v\n", constants.GreenColor(asset), constants.GreenColor(stewPkgPath))
 
-	binaryName, err := stew.InstallBinary(downloadPath, repo, systemInfo, &lockFile, false)
+	binaryName, err := stew.InstallBinary(downloadPath, repo, systemInfo, &lockFile, false, "")
 	if err != nil {
 		os.RemoveAll(downloadPath)
 		stew.CatchAndExit(err)

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -11,24 +11,21 @@ import (
 )
 
 // Install is executed when you run `stew install`
-func Install(cliInputs []string) {
+func Install(cliInput string) {
 	var err error
 
 	userOS, userArch, _, systemInfo, err := stew.Initialize()
 	stew.CatchAndExit(err)
 
-	for _, cliInput := range cliInputs {
-		if strings.Contains(cliInput, "Stewfile.lock.json") {
-			cliInputs, err = stew.ReadStewLockFileContents(cliInput)
-			stew.CatchAndExit(err)
-			break
-		}
-
-		if strings.Contains(cliInput, "Stewfile") {
-			cliInputs, err = stew.ReadStewfileContents(cliInput)
-			stew.CatchAndExit(err)
-			break
-		}
+	var cliInputs []string
+	if strings.Contains(cliInput, "Stewfile.lock.json") {
+		cliInputs, err = stew.ReadStewLockFileContents(cliInput)
+		stew.CatchAndExit(err)
+	} else if strings.Contains(cliInput, "Stewfile") {
+		cliInputs, err = stew.ReadStewfileContents(cliInput)
+		stew.CatchAndExit(err)
+	} else {
+		cliInputs = append(cliInputs, cliInput)
 	}
 
 	if len(cliInputs) == 0 {

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -17,132 +17,130 @@ func Install(cliInput string) {
 	userOS, userArch, _, systemInfo, err := stew.Initialize()
 	stew.CatchAndExit(err)
 
-	var cliInputs []string
-	if strings.Contains(cliInput, "Stewfile.lock.json") {
-		cliInputs, err = stew.ReadStewLockFileContents(cliInput)
+	var pkgs []stew.PackageData
+	if strings.HasSuffix(cliInput, "Stewfile.lock.json") {
+		pkgs, err = stew.ReadStewLockFileContents(cliInput)
 		stew.CatchAndExit(err)
-	} else if strings.Contains(cliInput, "Stewfile") {
-		cliInputs, err = stew.ReadStewfileContents(cliInput)
+	} else if strings.HasSuffix(cliInput, "Stewfile") {
+		pkgs, err = stew.ReadStewfileContents(cliInput)
 		stew.CatchAndExit(err)
 	} else {
-		cliInputs = append(cliInputs, cliInput)
+		pkg, err := stew.ParseCLIInput(cliInput)
+		stew.CatchAndExit(err)
+		pkgs = append(pkgs, pkg)
 	}
 
-	if len(cliInputs) == 0 {
+	if len(pkgs) == 0 {
 		stew.CatchAndExit(stew.EmptyCLIInputError{})
 	}
 
-	for _, cliInput := range cliInputs {
-		sp := constants.LoadingSpinner
-
-		stewBinPath := systemInfo.StewBinPath
-		stewPkgPath := systemInfo.StewPkgPath
-		stewLockFilePath := systemInfo.StewLockFilePath
-		stewTmpPath := systemInfo.StewTmpPath
-
-		parsedInput, err := stew.ParseCLIInput(cliInput)
-		stew.CatchAndExit(err)
-
-		owner := parsedInput.Owner
-		repo := parsedInput.Repo
-		tag := parsedInput.Tag
-		asset := parsedInput.Asset
-		downloadURL := parsedInput.DownloadURL
-
-		lockFile, err := stew.NewLockFile(stewLockFilePath, userOS, userArch)
-		stew.CatchAndExit(err)
-
-		err = os.RemoveAll(stewTmpPath)
-		stew.CatchAndExit(err)
-		err = os.MkdirAll(stewTmpPath, 0755)
-		stew.CatchAndExit(err)
-
-		var githubProject stew.GithubProject
-		if parsedInput.IsGithubInput {
-			fmt.Println(constants.GreenColor(owner + "/" + repo))
-			sp.Start()
-			githubProject, err = stew.NewGithubProject(owner, repo)
-			sp.Stop()
-			stew.CatchAndExit(err)
-
-			// This will make sure that there are any tags at all
-			releaseTags, err := stew.GetGithubReleasesTags(githubProject)
-			stew.CatchAndExit(err)
-
-			if tag == "" || tag == "latest" {
-				tag = githubProject.Releases[0].TagName
-			}
-
-			// Need to make sure user input tag is in the tags
-			tagIndex, tagFound := stew.Contains(releaseTags, tag)
-			if !tagFound {
-				tag, err = stew.WarningPromptSelect(fmt.Sprintf("Could not find a release with the tag %v - please select a release:", constants.YellowColor(tag)), releaseTags)
-				stew.CatchAndExit(err)
-				tagIndex, _ = stew.Contains(releaseTags, tag)
-			}
-
-			// Make sure there are any assets at all
-			releaseAssets, err := stew.GetGithubReleasesAssets(githubProject, tag)
-			stew.CatchAndExit(err)
-
-			if asset == "" {
-				asset, err = stew.DetectAsset(userOS, userArch, releaseAssets)
-			}
-			stew.CatchAndExit(err)
-
-			assetIndex, assetFound := stew.Contains(releaseAssets, asset)
-			if !assetFound {
-				asset, err = stew.WarningPromptSelect(fmt.Sprintf("Could not find the asset %v - please select an asset:", constants.YellowColor(asset)), releaseAssets)
-				stew.CatchAndExit(err)
-				assetIndex, _ = stew.Contains(releaseAssets, asset)
-			}
-
-			downloadURL = githubProject.Releases[tagIndex].Assets[assetIndex].DownloadURL
-
-		} else {
-			fmt.Println(constants.GreenColor(asset))
-		}
-
-		downloadPath := filepath.Join(stewPkgPath, asset)
-		err = stew.DownloadFile(downloadPath, downloadURL)
-		stew.CatchAndExit(err)
-		fmt.Printf("✅ Downloaded %v to %v\n", constants.GreenColor(asset), constants.GreenColor(stewPkgPath))
-
-		binaryName, err := stew.InstallBinary(downloadPath, repo, systemInfo, &lockFile, false)
-		if err != nil {
-			os.RemoveAll(downloadPath)
-			stew.CatchAndExit(err)
-		}
-
-		var packageData stew.PackageData
-		if parsedInput.IsGithubInput {
-			packageData = stew.PackageData{
-				Source: "github",
-				Owner:  githubProject.Owner,
-				Repo:   githubProject.Repo,
-				Tag:    tag,
-				Asset:  asset,
-				Binary: binaryName,
-				URL:    downloadURL,
-			}
-		} else {
-			packageData = stew.PackageData{
-				Source: "other",
-				Owner:  "",
-				Repo:   "",
-				Tag:    "",
-				Asset:  asset,
-				Binary: binaryName,
-				URL:    downloadURL,
-			}
-		}
-
-		lockFile.Packages = append(lockFile.Packages, packageData)
-
-		err = stew.WriteLockFileJSON(lockFile, stewLockFilePath)
-		stew.CatchAndExit(err)
-
-		fmt.Printf("✨ Successfully installed the %v binary in %v\n", constants.GreenColor(binaryName), constants.GreenColor(stewBinPath))
-
+	for _, pkg := range pkgs {
+		installOne(pkg, userOS, userArch, systemInfo)
 	}
+}
+
+func installOne(pkg stew.PackageData, userOS, userArch string, systemInfo stew.SystemInfo) {
+	sp := constants.LoadingSpinner
+
+	stewBinPath := systemInfo.StewBinPath
+	stewPkgPath := systemInfo.StewPkgPath
+	stewLockFilePath := systemInfo.StewLockFilePath
+	stewTmpPath := systemInfo.StewTmpPath
+
+	owner := pkg.Owner
+	repo := pkg.Repo
+	tag := pkg.Tag
+	asset := pkg.Asset
+	downloadURL := pkg.URL
+
+	lockFile, err := stew.NewLockFile(stewLockFilePath, userOS, userArch)
+	stew.CatchAndExit(err)
+
+	err = os.RemoveAll(stewTmpPath)
+	stew.CatchAndExit(err)
+	err = os.MkdirAll(stewTmpPath, 0755)
+	stew.CatchAndExit(err)
+
+	var githubProject stew.GithubProject
+	if pkg.Source == "github" {
+		fmt.Println(constants.GreenColor(owner + "/" + repo))
+		sp.Start()
+		githubProject, err = stew.NewGithubProject(owner, repo)
+		sp.Stop()
+		stew.CatchAndExit(err)
+
+		releaseTags, err := stew.GetGithubReleasesTags(githubProject)
+		stew.CatchAndExit(err)
+
+		if tag == "" || tag == "latest" {
+			tag = githubProject.Releases[0].TagName
+		}
+
+		tagIndex, tagFound := stew.Contains(releaseTags, tag)
+		if !tagFound {
+			tag, err = stew.WarningPromptSelect(fmt.Sprintf("Could not find a release with the tag %v - please select a release:", constants.YellowColor(tag)), releaseTags)
+			stew.CatchAndExit(err)
+			tagIndex, _ = stew.Contains(releaseTags, tag)
+		}
+
+		releaseAssets, err := stew.GetGithubReleasesAssets(githubProject, tag)
+		stew.CatchAndExit(err)
+
+		if asset == "" {
+			asset, err = stew.DetectAsset(userOS, userArch, releaseAssets)
+		}
+		stew.CatchAndExit(err)
+
+		assetIndex, assetFound := stew.Contains(releaseAssets, asset)
+		if !assetFound {
+			asset, err = stew.WarningPromptSelect(fmt.Sprintf("Could not find the asset %v - please select an asset:", constants.YellowColor(asset)), releaseAssets)
+			stew.CatchAndExit(err)
+			assetIndex, _ = stew.Contains(releaseAssets, asset)
+		}
+
+		downloadURL = githubProject.Releases[tagIndex].Assets[assetIndex].DownloadURL
+	} else {
+		fmt.Println(constants.GreenColor(asset))
+	}
+
+	downloadPath := filepath.Join(stewPkgPath, asset)
+	err = stew.DownloadFile(downloadPath, downloadURL)
+	stew.CatchAndExit(err)
+	fmt.Printf("✅ Downloaded %v to %v\n", constants.GreenColor(asset), constants.GreenColor(stewPkgPath))
+
+	binaryName, err := stew.InstallBinary(downloadPath, repo, systemInfo, &lockFile, false)
+	if err != nil {
+		os.RemoveAll(downloadPath)
+		stew.CatchAndExit(err)
+	}
+
+	var packageData stew.PackageData
+	if pkg.Source == "github" {
+		packageData = stew.PackageData{
+			Source: "github",
+			Owner:  githubProject.Owner,
+			Repo:   githubProject.Repo,
+			Tag:    tag,
+			Asset:  asset,
+			Binary: binaryName,
+			URL:    downloadURL,
+		}
+	} else {
+		packageData = stew.PackageData{
+			Source: "other",
+			Owner:  "",
+			Repo:   "",
+			Tag:    "",
+			Asset:  asset,
+			Binary: binaryName,
+			URL:    downloadURL,
+		}
+	}
+
+	lockFile.Packages = append(lockFile.Packages, packageData)
+
+	err = stew.WriteLockFileJSON(lockFile, stewLockFilePath)
+	stew.CatchAndExit(err)
+
+	fmt.Printf("✨ Successfully installed the %v binary in %v\n", constants.GreenColor(binaryName), constants.GreenColor(stewBinPath))
 }

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -32,7 +32,8 @@ func Install(cliInput string) {
 	} else {
 		pkg, err := stew.ParseCLIInput(cliInput)
 		stew.CatchAndExit(err)
-		installOne(pkg, userOS, userArch, systemInfo, false)
+		err = installOne(pkg, userOS, userArch, systemInfo, false)
+		stew.CatchAndExit(err)
 	}
 }
 

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/marwanhawari/stew/constants"
 	stew "github.com/marwanhawari/stew/lib"
@@ -18,10 +17,10 @@ func Install(cliInput string) {
 	stew.CatchAndExit(err)
 
 	var pkgs []stew.PackageData
-	if strings.HasSuffix(cliInput, "Stewfile.lock.json") {
+	if filepath.Base(cliInput) == "Stewfile.lock.json" {
 		pkgs, err = stew.ReadStewLockFileContents(cliInput)
 		stew.CatchAndExit(err)
-	} else if strings.HasSuffix(cliInput, "Stewfile") {
+	} else if filepath.Base(cliInput) == "Stewfile" {
 		pkgs, err = stew.ReadStewfileContents(cliInput)
 		stew.CatchAndExit(err)
 	} else {

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -11,34 +11,32 @@ import (
 
 // Install is executed when you run `stew install`
 func Install(cliInput string) {
-	var err error
-
 	userOS, userArch, _, systemInfo, err := stew.Initialize()
 	stew.CatchAndExit(err)
 
-	var pkgs []stew.PackageData
 	if filepath.Base(cliInput) == "Stewfile.lock.json" {
-		pkgs, err = stew.ReadStewLockFileContents(cliInput)
+		pkgs, err := stew.ReadStewLockFileContents(cliInput)
+		stew.CatchAndExit(err)
+		if len(pkgs) == 0 {
+			stew.CatchAndExit(stew.EmptyCLIInputError{})
+		}
+		err = installFromLockFile(pkgs, userOS, userArch, systemInfo)
 		stew.CatchAndExit(err)
 	} else if filepath.Base(cliInput) == "Stewfile" {
-		pkgs, err = stew.ReadStewfileContents(cliInput)
+		pkgs, err := stew.ReadStewfileContents(cliInput)
 		stew.CatchAndExit(err)
+		if len(pkgs) == 0 {
+			stew.CatchAndExit(stew.EmptyCLIInputError{})
+		}
+		installFromStewfile(pkgs, userOS, userArch, systemInfo)
 	} else {
 		pkg, err := stew.ParseCLIInput(cliInput)
 		stew.CatchAndExit(err)
-		pkgs = append(pkgs, pkg)
-	}
-
-	if len(pkgs) == 0 {
-		stew.CatchAndExit(stew.EmptyCLIInputError{})
-	}
-
-	for _, pkg := range pkgs {
-		installOne(pkg, userOS, userArch, systemInfo)
+		installOne(pkg, userOS, userArch, systemInfo, false)
 	}
 }
 
-func installOne(pkg stew.PackageData, userOS, userArch string, systemInfo stew.SystemInfo) {
+func installOne(pkg stew.PackageData, userOS, userArch string, systemInfo stew.SystemInfo, installingFromLockFile bool) error {
 	sp := constants.LoadingSpinner
 
 	stewBinPath := systemInfo.StewBinPath
@@ -46,30 +44,40 @@ func installOne(pkg stew.PackageData, userOS, userArch string, systemInfo stew.S
 	stewLockFilePath := systemInfo.StewLockFilePath
 	stewTmpPath := systemInfo.StewTmpPath
 
+	source := pkg.Source
 	owner := pkg.Owner
 	repo := pkg.Repo
 	tag := pkg.Tag
 	asset := pkg.Asset
+	desiredBinaryRename := pkg.Binary
 	downloadURL := pkg.URL
 
 	lockFile, err := stew.NewLockFile(stewLockFilePath, userOS, userArch)
-	stew.CatchAndExit(err)
+	if err != nil {
+		return err
+	}
 
-	err = os.RemoveAll(stewTmpPath)
-	stew.CatchAndExit(err)
-	err = os.MkdirAll(stewTmpPath, 0755)
-	stew.CatchAndExit(err)
+	if err = os.RemoveAll(stewTmpPath); err != nil {
+		return err
+	}
+	if err = os.MkdirAll(stewTmpPath, 0755); err != nil {
+		return err
+	}
 
 	var githubProject stew.GithubProject
-	if pkg.Source == "github" {
+	if source == "github" {
 		fmt.Println(constants.GreenColor(owner + "/" + repo))
 		sp.Start()
 		githubProject, err = stew.NewGithubProject(owner, repo)
 		sp.Stop()
-		stew.CatchAndExit(err)
+		if err != nil {
+			return err
+		}
 
 		releaseTags, err := stew.GetGithubReleasesTags(githubProject)
-		stew.CatchAndExit(err)
+		if err != nil {
+			return err
+		}
 
 		if tag == "" || tag == "latest" {
 			tag = githubProject.Releases[0].TagName
@@ -78,22 +86,30 @@ func installOne(pkg stew.PackageData, userOS, userArch string, systemInfo stew.S
 		tagIndex, tagFound := stew.Contains(releaseTags, tag)
 		if !tagFound {
 			tag, err = stew.WarningPromptSelect(fmt.Sprintf("Could not find a release with the tag %v - please select a release:", constants.YellowColor(tag)), releaseTags)
-			stew.CatchAndExit(err)
+			if err != nil {
+				return err
+			}
 			tagIndex, _ = stew.Contains(releaseTags, tag)
 		}
 
 		releaseAssets, err := stew.GetGithubReleasesAssets(githubProject, tag)
-		stew.CatchAndExit(err)
+		if err != nil {
+			return err
+		}
 
 		if asset == "" {
 			asset, err = stew.DetectAsset(userOS, userArch, releaseAssets)
 		}
-		stew.CatchAndExit(err)
+		if err != nil {
+			return err
+		}
 
 		assetIndex, assetFound := stew.Contains(releaseAssets, asset)
 		if !assetFound {
 			asset, err = stew.WarningPromptSelect(fmt.Sprintf("Could not find the asset %v - please select an asset:", constants.YellowColor(asset)), releaseAssets)
-			stew.CatchAndExit(err)
+			if err != nil {
+				return err
+			}
 			assetIndex, _ = stew.Contains(releaseAssets, asset)
 		}
 
@@ -104,17 +120,20 @@ func installOne(pkg stew.PackageData, userOS, userArch string, systemInfo stew.S
 
 	downloadPath := filepath.Join(stewPkgPath, asset)
 	err = stew.DownloadFile(downloadPath, downloadURL)
-	stew.CatchAndExit(err)
+	if err != nil {
+		return err
+	}
 	fmt.Printf("✅ Downloaded %v to %v\n", constants.GreenColor(asset), constants.GreenColor(stewPkgPath))
 
-	binaryName, err := stew.InstallBinary(downloadPath, repo, systemInfo, &lockFile, false)
+	binaryName, err := stew.InstallBinary(downloadPath, repo, systemInfo, &lockFile, installingFromLockFile, desiredBinaryRename)
 	if err != nil {
-		os.RemoveAll(downloadPath)
-		stew.CatchAndExit(err)
+		if err := os.RemoveAll(downloadPath); err != nil {
+			return err
+		}
 	}
 
 	var packageData stew.PackageData
-	if pkg.Source == "github" {
+	if source == "github" {
 		packageData = stew.PackageData{
 			Source: "github",
 			Owner:  githubProject.Owner,
@@ -136,10 +155,38 @@ func installOne(pkg stew.PackageData, userOS, userArch string, systemInfo stew.S
 		}
 	}
 
-	lockFile.Packages = append(lockFile.Packages, packageData)
+	indexInLockFile, binaryFoundInLockFile := stew.FindBinaryInLockFile(lockFile, binaryName)
+	if installingFromLockFile && binaryFoundInLockFile {
+		lockFile.Packages[indexInLockFile] = packageData
+	} else {
+		lockFile.Packages = append(lockFile.Packages, packageData)
+	}
 
 	err = stew.WriteLockFileJSON(lockFile, stewLockFilePath)
-	stew.CatchAndExit(err)
+	if err != nil {
+		return err
+	}
 
 	fmt.Printf("✨ Successfully installed the %v binary in %v\n", constants.GreenColor(binaryName), constants.GreenColor(stewBinPath))
+	return nil
+}
+
+func installFromLockFile(pkgs []stew.PackageData, userOS, userArch string, systemInfo stew.SystemInfo) error {
+	for _, pkg := range pkgs {
+		err := installOne(pkg, userOS, userArch, systemInfo, true)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func installFromStewfile(pkgs []stew.PackageData, userOS, userArch string, systemInfo stew.SystemInfo) {
+	for _, pkg := range pkgs {
+		err := installOne(pkg, userOS, userArch, systemInfo, false)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			continue
+		}
+	}
 }

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -103,7 +103,7 @@ func upgradeOne(binaryName, userOS, userArch string, lockFile stew.LockFile, sys
 	}
 	fmt.Printf("✅ Downloaded %v to %v\n", constants.GreenColor(asset), constants.GreenColor(stewPkgPath))
 
-	_, err = stew.InstallBinary(downloadPath, repo, systemInfo, &lockFile, true)
+	_, err = stew.InstallBinary(downloadPath, repo, systemInfo, &lockFile, true, pkg.Binary)
 	if err != nil {
 		if err := os.RemoveAll(downloadPath); err != nil {
 			return err

--- a/lib/stewfile_test.go
+++ b/lib/stewfile_test.go
@@ -47,12 +47,6 @@ https://github.com/sharkdp/hyperfine/releases/download/v1.12.0/hyperfine-v1.12.0
 marwanhawari/ppath@v0.0.3
 `
 
-var testStewfileSlice []string = []string{
-	"junegunn/fzf@0.29.0",
-	"https://github.com/sharkdp/hyperfine/releases/download/v1.12.0/hyperfine-v1.12.0-x86_64-apple-darwin.tar.gz",
-	"marwanhawari/ppath@v0.0.3",
-}
-
 var testStewLockFileContents string = `{
 	"os": "darwin",
 	"arch": "arm64",
@@ -88,10 +82,34 @@ var testStewLockFileContents string = `{
 }
 `
 
-var testStewLockFileSlice []string = []string{
-	"cli/cli@v2.4.0",
-	"junegunn/fzf@0.29.0",
-	"https://github.com/sharkdp/hyperfine/releases/download/v1.12.0/hyperfine-v1.12.0-x86_64-apple-darwin.tar.gz",
+var testStewLockFileSlice []PackageData = []PackageData{
+	{
+		Source: "github",
+		Owner:  "cli",
+		Repo:   "cli",
+		Tag:    "v2.4.0",
+		Asset:  "gh_2.4.0_macOS_amd64.tar.gz",
+		Binary: "gh",
+		URL:    "https://github.com/cli/cli/releases/download/v2.4.0/gh_2.4.0_macOS_amd64.tar.gz",
+	},
+	{
+		Source: "github",
+		Owner:  "junegunn",
+		Repo:   "fzf",
+		Tag:    "0.29.0",
+		Asset:  "fzf-0.29.0-darwin_arm64.zip",
+		Binary: "fzf",
+		URL:    "https://github.com/junegunn/fzf/releases/download/0.29.0/fzf-0.29.0-darwin_arm64.zip",
+	},
+	{
+		Source: "other",
+		Owner:  "",
+		Repo:   "",
+		Tag:    "",
+		Asset:  "hyperfine-v1.12.0-x86_64-apple-darwin.tar.gz",
+		Binary: "hyperfine",
+		URL:    "https://github.com/sharkdp/hyperfine/releases/download/v1.12.0/hyperfine-v1.12.0-x86_64-apple-darwin.tar.gz",
+	},
 }
 
 func Test_readLockFileJSON(t *testing.T) {
@@ -226,9 +244,28 @@ func TestRemovePackage(t *testing.T) {
 }
 
 func TestReadStewfileContents(t *testing.T) {
+	var testStewfileSlice []PackageData = []PackageData{
+		{
+			Source: "github",
+			Owner:  "junegunn",
+			Repo:   "fzf",
+			Tag:    "0.29.0",
+		},
+		{
+			Source: "other",
+			Asset:  "hyperfine-v1.12.0-x86_64-apple-darwin.tar.gz",
+			URL:    "https://github.com/sharkdp/hyperfine/releases/download/v1.12.0/hyperfine-v1.12.0-x86_64-apple-darwin.tar.gz",
+		},
+		{
+			Source: "github",
+			Owner:  "marwanhawari",
+			Repo:   "ppath",
+			Tag:    "v0.0.3",
+		},
+	}
 	tests := []struct {
 		name    string
-		want    []string
+		want    []PackageData
 		wantErr bool
 	}{
 		{
@@ -259,7 +296,7 @@ func TestReadStewfileContents(t *testing.T) {
 func TestReadStewLockFileContents(t *testing.T) {
 	tests := []struct {
 		name    string
-		want    []string
+		want    []PackageData
 		wantErr bool
 	}{
 		{

--- a/lib/util.go
+++ b/lib/util.go
@@ -242,7 +242,7 @@ func parseGithubInput(cliInput string) (PackageData, error) {
 }
 
 func parseURLInput(cliInput string) (PackageData, error) {
-	return PackageData{Source: "github", Asset: filepath.Base(cliInput), URL: cliInput}, nil
+	return PackageData{Source: "other", Asset: filepath.Base(cliInput), URL: cliInput}, nil
 }
 
 // Contains checks if a string slice contains a given target

--- a/lib/util.go
+++ b/lib/util.go
@@ -191,50 +191,40 @@ func ValidateCLIInput(cliInput string) error {
 	return nil
 }
 
-// CLIInput contains information about the parsed CLI input
-type CLIInput struct {
-	IsGithubInput bool
-	Owner         string
-	Repo          string
-	Tag           string
-	Asset         string
-	DownloadURL   string
-}
-
-// ParseCLIInput creates a new instance of the CLIInput struct
-func ParseCLIInput(cliInput string) (CLIInput, error) {
+// ParseCLIInput creates a new instance of the PackageData struct
+func ParseCLIInput(cliInput string) (PackageData, error) {
 	err := ValidateCLIInput(cliInput)
 	if err != nil {
-		return CLIInput{}, err
+		return PackageData{}, err
 	}
 
 	reGithub, err := regexp.Compile(constants.RegexGithub)
 	if err != nil {
-		return CLIInput{}, err
+		return PackageData{}, err
 	}
 	reURL, err := regexp.Compile(constants.RegexURL)
 	if err != nil {
-		return CLIInput{}, err
+		return PackageData{}, err
 	}
-	var parsedInput CLIInput
+	var parsedInput PackageData
 	if reGithub.MatchString(cliInput) {
 		parsedInput, err = parseGithubInput(cliInput)
 	} else if reURL.MatchString(cliInput) {
 		parsedInput, err = parseURLInput(cliInput)
 	} else {
-		return CLIInput{}, UnrecognizedInputError{}
+		return PackageData{}, UnrecognizedInputError{}
 	}
 	if err != nil {
-		return CLIInput{}, err
+		return PackageData{}, err
 	}
 
 	return parsedInput, nil
 
 }
 
-func parseGithubInput(cliInput string) (CLIInput, error) {
-	parsedInput := CLIInput{}
-	parsedInput.IsGithubInput = true
+func parseGithubInput(cliInput string) (PackageData, error) {
+	parsedInput := PackageData{}
+	parsedInput.Source = "github"
 	trimmedString := strings.Trim(strings.Trim(strings.TrimSpace(cliInput), "/"), "@")
 	splitInput := strings.SplitN(trimmedString, "@", 2)
 
@@ -251,8 +241,8 @@ func parseGithubInput(cliInput string) (CLIInput, error) {
 
 }
 
-func parseURLInput(cliInput string) (CLIInput, error) {
-	return CLIInput{IsGithubInput: false, Asset: filepath.Base(cliInput), DownloadURL: cliInput}, nil
+func parseURLInput(cliInput string) (PackageData, error) {
+	return PackageData{Source: "github", Asset: filepath.Base(cliInput), URL: cliInput}, nil
 }
 
 // Contains checks if a string slice contains a given target

--- a/lib/util.go
+++ b/lib/util.go
@@ -139,48 +139,41 @@ func walkDir(rootDir string) ([]string, error) {
 	return allFilePaths, err
 }
 
-func getBinary(filePaths []string, repo string) (string, string, error) {
-	binaryFile := ""
-	binaryName := ""
-	var err error
-	executableFiles := []string{}
+type ExecutableFileInfo struct {
+	fileName string
+	filePath string
+}
+
+func getBinary(filePaths []string, desiredBinaryRename string) (string, string, error) {
+	executableFiles := []ExecutableFileInfo{}
 	for _, fullPath := range filePaths {
 		fileNameBase := filepath.Base(fullPath)
 		fileIsExecutable, err := isExecutableFile(fullPath)
 		if err != nil {
 			return "", "", err
 		}
-		if fileNameBase == repo && fileIsExecutable {
-			binaryFile = fullPath
-			binaryName = repo
-			executableFiles = append(executableFiles, fullPath)
-		} else if filepath.Ext(fullPath) == ".exe" {
-			binaryFile = fullPath
-			binaryName = filepath.Base(fullPath)
-			executableFiles = append(executableFiles, fullPath)
-		} else if fileIsExecutable {
-			executableFiles = append(executableFiles, fullPath)
+		if !fileIsExecutable {
+			continue
 		}
+		executableFiles = append(executableFiles, ExecutableFileInfo{fileName: fileNameBase, filePath: fullPath})
 	}
 
-	if binaryFile == "" {
-		if len(executableFiles) == 1 {
-			binaryFile = executableFiles[0]
-			binaryName = filepath.Base(binaryFile)
-		} else if len(executableFiles) != 1 {
-			binaryFile, err = WarningPromptSelect("Could not automatically detect the binary. Please select it manually:", filePaths)
-			if err != nil {
-				return "", "", err
-			}
-			binaryName = filepath.Base(binaryFile)
-			binaryName, err = PromptRenameBinary(binaryName)
-			if err != nil {
-				return "", "", nil
-			}
+	if len(executableFiles) != 1 {
+		binaryFilePath, err := WarningPromptSelect("Could not automatically detect the binary. Please select it manually:", filePaths)
+		if err != nil {
+			return "", "", err
 		}
+		binaryName, err := PromptRenameBinary(filepath.Base(binaryFilePath))
+		if err != nil {
+			return "", "", nil
+		}
+		return binaryFilePath, binaryName, nil
 	}
 
-	return binaryFile, binaryName, nil
+	if desiredBinaryRename != "" {
+		return executableFiles[0].filePath, desiredBinaryRename, nil
+	}
+	return executableFiles[0].filePath, executableFiles[0].fileName, nil
 }
 
 // ValidateCLIInput makes sure the CLI input isn't empty
@@ -264,7 +257,7 @@ func FindBinaryInLockFile(lockFile LockFile, binaryName string) (int, bool) {
 	return -1, false
 }
 
-func extractBinary(downloadedFilePath, tmpExtractionPath string) error {
+func extractBinary(downloadedFilePath, tmpExtractionPath, desiredBinaryRename string) error {
 	isArchive := isArchiveFile(downloadedFilePath)
 	if isArchive {
 		err := archiver.Unarchive(downloadedFilePath, tmpExtractionPath)
@@ -274,6 +267,9 @@ func extractBinary(downloadedFilePath, tmpExtractionPath string) error {
 		return nil
 	}
 	originalBinaryName := filepath.Base(downloadedFilePath)
+	if desiredBinaryRename != "" {
+		return copyFile(downloadedFilePath, filepath.Join(tmpExtractionPath, desiredBinaryRename))
+	}
 	renamedBinaryName, err := PromptRenameBinary(originalBinaryName)
 	if err != nil {
 		return err
@@ -282,9 +278,9 @@ func extractBinary(downloadedFilePath, tmpExtractionPath string) error {
 }
 
 // InstallBinary will extract the binary and copy it to the ~/.stew/bin path
-func InstallBinary(downloadedFilePath string, repo string, systemInfo SystemInfo, lockFile *LockFile, overwriteFromUpgrade bool) (string, error) {
+func InstallBinary(downloadedFilePath string, repo string, systemInfo SystemInfo, lockFile *LockFile, overwriteFromUpgrade bool, desiredBinaryRename string) (string, error) {
 	tmpExtractionPath, stewPkgPath, binaryInstallPath := systemInfo.StewTmpPath, systemInfo.StewPkgPath, systemInfo.StewBinPath
-	if err := extractBinary(downloadedFilePath, tmpExtractionPath); err != nil {
+	if err := extractBinary(downloadedFilePath, tmpExtractionPath, desiredBinaryRename); err != nil {
 		return "", err
 	}
 
@@ -293,7 +289,7 @@ func InstallBinary(downloadedFilePath string, repo string, systemInfo SystemInfo
 		return "", err
 	}
 
-	binaryFileInTmpExtractionPath, binaryName, err := getBinary(allFilePaths, repo)
+	binaryFileInTmpExtractionPath, binaryName, err := getBinary(allFilePaths, desiredBinaryRename)
 	if err != nil {
 		return "", err
 	}

--- a/lib/util_test.go
+++ b/lib/util_test.go
@@ -311,7 +311,7 @@ func Test_getBinary(t *testing.T) {
 			wantBinaryFile := filepath.Join(tempDir, tt.binaryName)
 			wantBinaryName := filepath.Base(wantBinaryFile)
 
-			got, got1, err := getBinary(testFilePaths, tt.args.repo)
+			got, got1, err := getBinary(testFilePaths, "")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getBinary() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -357,7 +357,7 @@ func Test_getBinaryError(t *testing.T) {
 			wantBinaryFile := ""
 			wantBinaryName := ""
 
-			got, got1, err := getBinary(testFilePaths, tt.args.repo)
+			got, got1, err := getBinary(testFilePaths, "")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getBinary() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -625,7 +625,7 @@ func Test_extractBinary(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			DownloadFile(tt.args.downloadedFilePath, tt.url)
 
-			if err := extractBinary(tt.args.downloadedFilePath, tt.args.tmpExtractionPath); (err != nil) != tt.wantErr {
+			if err := extractBinary(tt.args.downloadedFilePath, tt.args.tmpExtractionPath, ""); (err != nil) != tt.wantErr {
 				t.Errorf("extractBinary() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -683,7 +683,7 @@ func TestInstallBinary(t *testing.T) {
 				t.Errorf("Could not download file to %v", downloadedFilePath)
 			}
 
-			got, err := InstallBinary(downloadedFilePath, repo, systemInfo, &lockFile, true)
+			got, err := InstallBinary(downloadedFilePath, repo, systemInfo, &lockFile, true, "")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("InstallBinary() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -747,7 +747,7 @@ func TestInstallBinary_Fail(t *testing.T) {
 				t.Errorf("Could not download file to %v", downloadedFilePath)
 			}
 
-			got, err := InstallBinary(downloadedFilePath, repo, systemInfo, &lockFile, false)
+			got, err := InstallBinary(downloadedFilePath, repo, systemInfo, &lockFile, false, "")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("InstallBinary() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/lib/util_test.go
+++ b/lib/util_test.go
@@ -412,7 +412,7 @@ func TestParseCLIInput(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    CLIInput
+		want    PackageData
 		wantErr bool
 	}{
 		{
@@ -420,7 +420,7 @@ func TestParseCLIInput(t *testing.T) {
 			args: args{
 				cliInput: "",
 			},
-			want:    CLIInput{},
+			want:    PackageData{},
 			wantErr: true,
 		},
 		{
@@ -428,10 +428,10 @@ func TestParseCLIInput(t *testing.T) {
 			args: args{
 				cliInput: "marwanhawari/ppath",
 			},
-			want: CLIInput{
-				IsGithubInput: true,
-				Owner:         "marwanhawari",
-				Repo:          "ppath",
+			want: PackageData{
+				Source: "github",
+				Owner:  "marwanhawari",
+				Repo:   "ppath",
 			},
 			wantErr: false,
 		},
@@ -440,10 +440,10 @@ func TestParseCLIInput(t *testing.T) {
 			args: args{
 				cliInput: "https://github.com/marwanhawari/ppath/releases/download/v0.0.3/ppath-v0.0.3-darwin-arm64.tar.gz",
 			},
-			want: CLIInput{
-				IsGithubInput: false,
-				Asset:         "ppath-v0.0.3-darwin-arm64.tar.gz",
-				DownloadURL:   "https://github.com/marwanhawari/ppath/releases/download/v0.0.3/ppath-v0.0.3-darwin-arm64.tar.gz",
+			want: PackageData{
+				Source: "other",
+				Asset:  "ppath-v0.0.3-darwin-arm64.tar.gz",
+				URL:    "https://github.com/marwanhawari/ppath/releases/download/v0.0.3/ppath-v0.0.3-darwin-arm64.tar.gz",
 			},
 			wantErr: false,
 		},
@@ -452,7 +452,7 @@ func TestParseCLIInput(t *testing.T) {
 			args: args{
 				cliInput: "marwan",
 			},
-			want:    CLIInput{},
+			want:    PackageData{},
 			wantErr: true,
 		},
 	}
@@ -477,7 +477,7 @@ func Test_parseGithubInput(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    CLIInput
+		want    PackageData
 		wantErr bool
 	}{
 		{
@@ -485,10 +485,10 @@ func Test_parseGithubInput(t *testing.T) {
 			args: args{
 				cliInput: "marwanhawari/ppath",
 			},
-			want: CLIInput{
-				IsGithubInput: true,
-				Owner:         "marwanhawari",
-				Repo:          "ppath",
+			want: PackageData{
+				Source: "github",
+				Owner:  "marwanhawari",
+				Repo:   "ppath",
 			},
 			wantErr: false,
 		},
@@ -497,11 +497,11 @@ func Test_parseGithubInput(t *testing.T) {
 			args: args{
 				cliInput: "marwanhawari/ppath@v0.0.3",
 			},
-			want: CLIInput{
-				IsGithubInput: true,
-				Owner:         "marwanhawari",
-				Repo:          "ppath",
-				Tag:           "v0.0.3",
+			want: PackageData{
+				Source: "github",
+				Owner:  "marwanhawari",
+				Repo:   "ppath",
+				Tag:    "v0.0.3",
 			},
 			wantErr: false,
 		},
@@ -527,7 +527,7 @@ func Test_parseURLInput(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    CLIInput
+		want    PackageData
 		wantErr bool
 	}{
 		{
@@ -535,10 +535,10 @@ func Test_parseURLInput(t *testing.T) {
 			args: args{
 				cliInput: "https://github.com/marwanhawari/ppath/releases/download/v0.0.3/ppath-v0.0.3-darwin-arm64.tar.gz",
 			},
-			want: CLIInput{
-				IsGithubInput: false,
-				Asset:         "ppath-v0.0.3-darwin-arm64.tar.gz",
-				DownloadURL:   "https://github.com/marwanhawari/ppath/releases/download/v0.0.3/ppath-v0.0.3-darwin-arm64.tar.gz",
+			want: PackageData{
+				Source: "other",
+				Asset:  "ppath-v0.0.3-darwin-arm64.tar.gz",
+				URL:    "https://github.com/marwanhawari/ppath/releases/download/v0.0.3/ppath-v0.0.3-darwin-arm64.tar.gz",
 			},
 			wantErr: false,
 		},

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ func main() {
 				Usage:   "Install a binary. The input can be a GitHub repo or a URL. [Ex: stew install marwanhawari/ppath]",
 				Aliases: []string{"i"},
 				Action: func(c *cli.Context) error {
-					cmd.Install(c.Args())
+					cmd.Install(c.Args().First())
 					return nil
 				},
 			},


### PR DESCRIPTION
This PR allows users to headlessly batch install packages from a `Stewfile.lock.json`. The only case where headless install fails is if 0 or >1 executables are detected in the archive.

Breaking change:
- `stew install` now only allows a single argument