### PR TITLE
search command uses install not browse

### DIFF
--- a/cmd/search.go
+++ b/cmd/search.go
@@ -31,6 +31,6 @@ func Search(cliInput string) {
 
 	searchResultIndex, _ := stew.Contains(formattedSearchResults, githubProjectName)
 
-	Browse(githubSearch.Items[searchResultIndex].FullName)
+	Install(githubSearch.Items[searchResultIndex].FullName)
 
 }


### PR DESCRIPTION
Better UX to just install the package once they find it through the search command.