### PR TITLE
fix: config path suggestions

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -23,12 +23,9 @@ func Config() {
 		return
 	}
 
-	defaultStewPath, err := stew.GetDefaultStewPath(userOS)
+	config, err := stew.ReadStewConfigJSON(stewConfigFilePath)
 	stew.CatchAndExit(err)
-	defaultStewBinPath, err := stew.GetDefaultStewBinPath(userOS)
-	stew.CatchAndExit(err)
-
-	newStewPath, newStewBinPath, err := stew.PromptConfig(defaultStewPath, defaultStewBinPath)
+	newStewPath, newStewBinPath, err := stew.PromptConfig(config.StewPath, config.StewBinPath)
 	stew.CatchAndExit(err)
 
 	newStewConfig := stew.StewConfig{StewPath: newStewPath, StewBinPath: newStewBinPath}

--- a/lib/config.go
+++ b/lib/config.go
@@ -87,7 +87,7 @@ type StewConfig struct {
 	StewBinPath string `json:"stewBinPath"`
 }
 
-func readStewConfigJSON(stewConfigFilePath string) (StewConfig, error) {
+func ReadStewConfigJSON(stewConfigFilePath string) (StewConfig, error) {
 
 	stewConfigFileBytes, err := ioutil.ReadFile(stewConfigFilePath)
 	if err != nil {
@@ -141,7 +141,7 @@ func NewStewConfig(userOS string) (StewConfig, error) {
 		return StewConfig{}, err
 	}
 	if configExists {
-		stewConfig, err = readStewConfigJSON(stewConfigFilePath)
+		stewConfig, err = ReadStewConfigJSON(stewConfigFilePath)
 		if err != nil {
 			return StewConfig{}, err
 		}


### PR DESCRIPTION
Previously `stew config` would suggest the default stewPath and stewBinPath.

Now, `stew config` suggests whatever your current stewPath and stewBinPath values are.