### PR TITLE
chore: replace ioutil with io and os

### DIFF
--- a/lib/config.go
+++ b/lib/config.go
@@ -3,7 +3,6 @@ package stew
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -89,7 +88,7 @@ type StewConfig struct {
 
 func ReadStewConfigJSON(stewConfigFilePath string) (StewConfig, error) {
 
-	stewConfigFileBytes, err := ioutil.ReadFile(stewConfigFilePath)
+	stewConfigFileBytes, err := os.ReadFile(stewConfigFilePath)
 	if err != nil {
 		return StewConfig{}, err
 	}
@@ -111,7 +110,7 @@ func WriteStewConfigJSON(stewConfigFileJSON StewConfig, outputPath string) error
 		return err
 	}
 
-	err = ioutil.WriteFile(outputPath, stewConfigFileBytes, 0644)
+	err = os.WriteFile(outputPath, stewConfigFileBytes, 0644)
 	if err != nil {
 		return err
 	}

--- a/lib/http.go
+++ b/lib/http.go
@@ -2,7 +2,7 @@ package stew
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -34,7 +34,7 @@ func getHTTPResponseBody(url string) (string, error) {
 		return "", NonZeroStatusCodeError{res.StatusCode}
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return "", err
 	}

--- a/lib/stewfile.go
+++ b/lib/stewfile.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -31,7 +30,7 @@ type PackageData struct {
 
 func readLockFileJSON(lockFilePath string) (LockFile, error) {
 
-	lockFileBytes, err := ioutil.ReadFile(lockFilePath)
+	lockFileBytes, err := os.ReadFile(lockFilePath)
 	if err != nil {
 		return LockFile{}, err
 	}
@@ -53,7 +52,7 @@ func WriteLockFileJSON(lockFileJSON LockFile, outputPath string) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(outputPath, lockFileBytes, 0644)
+	err = os.WriteFile(outputPath, lockFileBytes, 0644)
 	if err != nil {
 		return err
 	}

--- a/lib/stewfile_test.go
+++ b/lib/stewfile_test.go
@@ -1,7 +1,6 @@
 package stew
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -279,7 +278,7 @@ func TestReadStewfileContents(t *testing.T) {
 
 			tempDir := t.TempDir()
 			testStewfilePath := filepath.Join(tempDir, "Stewfile")
-			ioutil.WriteFile(testStewfilePath, []byte(testStewfileContents), 0644)
+			os.WriteFile(testStewfilePath, []byte(testStewfileContents), 0644)
 
 			got, err := ReadStewfileContents(testStewfilePath)
 			if (err != nil) != tt.wantErr {
@@ -310,7 +309,7 @@ func TestReadStewLockFileContents(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tempDir := t.TempDir()
 			testStewLockFilePath := filepath.Join(tempDir, "Stewfile.lock.json")
-			ioutil.WriteFile(testStewLockFilePath, []byte(testStewLockFileContents), 0644)
+			os.WriteFile(testStewLockFilePath, []byte(testStewLockFileContents), 0644)
 
 			got, err := ReadStewLockFileContents(testStewLockFilePath)
 			if (err != nil) != tt.wantErr {
@@ -453,8 +452,8 @@ func TestDeleteAssetAndBinary(t *testing.T) {
 			os.MkdirAll(filepath.Join(tempDir, "bin"), 0755)
 			testStewBinaryPath := filepath.Join(tempDir, "bin", "testBinary")
 
-			ioutil.WriteFile(testStewAssetPath, []byte("This is a test asset"), 0644)
-			ioutil.WriteFile(testStewBinaryPath, []byte("This is a test binary"), 0644)
+			os.WriteFile(testStewAssetPath, []byte("This is a test asset"), 0644)
+			os.WriteFile(testStewBinaryPath, []byte("This is a test binary"), 0644)
 
 			assetExists, _ := PathExists(testStewAssetPath)
 			binaryExists, _ := PathExists(testStewBinaryPath)

--- a/lib/util_test.go
+++ b/lib/util_test.go
@@ -1,7 +1,6 @@
 package stew
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -80,9 +79,9 @@ func Test_isExecutableFile(t *testing.T) {
 			tempDir := t.TempDir()
 			testExecutableFilePath := filepath.Join(tempDir, tt.args.filePath)
 			if tt.want {
-				ioutil.WriteFile(testExecutableFilePath, []byte("An executable file"), 0755)
+				os.WriteFile(testExecutableFilePath, []byte("An executable file"), 0755)
 			} else {
-				ioutil.WriteFile(testExecutableFilePath, []byte("Not an executable file"), 0644)
+				os.WriteFile(testExecutableFilePath, []byte("Not an executable file"), 0644)
 			}
 
 			got, err := isExecutableFile(testExecutableFilePath)
@@ -129,7 +128,7 @@ func TestPathExists(t *testing.T) {
 			tempDir := t.TempDir()
 			testFilePath := filepath.Join(tempDir, tt.args.path)
 			if tt.want {
-				ioutil.WriteFile(testFilePath, []byte("A test file"), 0644)
+				os.WriteFile(testFilePath, []byte("A test file"), 0644)
 			}
 
 			got, err := PathExists(testFilePath)
@@ -209,7 +208,7 @@ func Test_copyFile(t *testing.T) {
 			srcFilePath := filepath.Join(tempDir, tt.args.srcFile)
 			destFilePath := filepath.Join(tempDir, tt.args.destFile)
 
-			ioutil.WriteFile(srcFilePath, []byte("A test file"), 0644)
+			os.WriteFile(srcFilePath, []byte("A test file"), 0644)
 
 			srcExists, _ := PathExists(srcFilePath)
 			destExists, _ := PathExists(destFilePath)
@@ -251,9 +250,9 @@ func Test_walkDir(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tempDir := t.TempDir()
 
-			ioutil.WriteFile(filepath.Join(tempDir, "testFile.txt"), []byte("A test file"), 0644)
+			os.WriteFile(filepath.Join(tempDir, "testFile.txt"), []byte("A test file"), 0644)
 			os.MkdirAll(filepath.Join(tempDir, "bin"), 0755)
-			ioutil.WriteFile(filepath.Join(tempDir, "bin", "binDirTestFile.txt"), []byte("Another test file"), 0644)
+			os.WriteFile(filepath.Join(tempDir, "bin", "binDirTestFile.txt"), []byte("Another test file"), 0644)
 
 			want := []string{filepath.Join(tempDir, "bin", "binDirTestFile.txt"), filepath.Join(tempDir, "testFile.txt")}
 
@@ -309,9 +308,9 @@ func Test_getBinary(t *testing.T) {
 			tempDir := t.TempDir()
 
 			testBinaryFilePath := filepath.Join(tempDir, tt.binaryName)
-			ioutil.WriteFile(testBinaryFilePath, []byte("An executable file"), 0755)
+			os.WriteFile(testBinaryFilePath, []byte("An executable file"), 0755)
 			testNonBinaryFilePath := filepath.Join(tempDir, "testNonBinary")
-			ioutil.WriteFile(testNonBinaryFilePath, []byte("Not an executable file"), 0644)
+			os.WriteFile(testNonBinaryFilePath, []byte("Not an executable file"), 0644)
 
 			testFilePaths := []string{testBinaryFilePath, testNonBinaryFilePath}
 
@@ -357,7 +356,7 @@ func Test_getBinaryError(t *testing.T) {
 			tempDir := t.TempDir()
 
 			testNonBinaryFilePath := filepath.Join(tempDir, "testNonBinary")
-			ioutil.WriteFile(testNonBinaryFilePath, []byte("Not an executable file"), 0644)
+			os.WriteFile(testNonBinaryFilePath, []byte("Not an executable file"), 0644)
 
 			testFilePaths := []string{testNonBinaryFilePath}
 


### PR DESCRIPTION
`ioutil` is deprecated. Replaced all usage with `os` or `io`