### PR TITLE
throw error on binary hash mismatch

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -103,7 +103,7 @@ func upgradeOne(binaryName, userOS, userArch string, lockFile stew.LockFile, sys
 	}
 	fmt.Printf("✅ Downloaded %v to %v\n", constants.GreenColor(asset), constants.GreenColor(stewPkgPath))
 
-	_, binaryHash, err := stew.InstallBinary(downloadPath, repo, systemInfo, &lockFile, true, pkg.Binary, pkg.BinaryHash)
+	_, binaryHash, err := stew.InstallBinary(downloadPath, repo, systemInfo, &lockFile, true, pkg.Binary, "")
 	if err != nil {
 		if err := os.RemoveAll(downloadPath); err != nil {
 			return err

--- a/lib/errors.go
+++ b/lib/errors.go
@@ -162,3 +162,11 @@ type InvalidGithubSearchQueryError struct {
 func (e InvalidGithubSearchQueryError) Error() string {
 	return fmt.Sprintf("%v The search query %v contains invalid characters", constants.RedColor("Error:"), constants.RedColor(e.SearchQuery))
 }
+
+type BinaryMismatchError struct {
+	BinaryName string
+}
+
+func (e BinaryMismatchError) Error() string {
+	return fmt.Sprintf("%v The hash for the downloaded binary %v does not match the hash in the lockfile", constants.RedColor("Error:"), constants.RedColor(e.BinaryName))
+}

--- a/lib/errors_test.go
+++ b/lib/errors_test.go
@@ -478,3 +478,32 @@ func TestInvalidGithubSearchQueryError_Error(t *testing.T) {
 		})
 	}
 }
+
+func TestBinaryMismatchError_Error(t *testing.T) {
+	type fields struct {
+		BinaryName string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "test1",
+			fields: fields{
+				BinaryName: "testBinaryName",
+			},
+			want: fmt.Sprintf("%v The hash for the downloaded binary %v does not match the hash in the lockfile", constants.RedColor("Error:"), constants.RedColor("testBinaryName")),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := BinaryMismatchError{
+				BinaryName: tt.fields.BinaryName,
+			}
+			if got := e.Error(); got != tt.want {
+				t.Errorf("BinaryMismatchError.Error() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/lib/util.go
+++ b/lib/util.go
@@ -128,7 +128,11 @@ func copyFile(srcFile, destFile string) error {
 func walkDir(rootDir string) ([]string, error) {
 	allFilePaths := []string{}
 	err := filepath.Walk(rootDir, func(filePath string, fileInfo os.FileInfo, err error) error {
-		if !fileInfo.IsDir() {
+		if err != nil {
+			return err
+		}
+		fileMode := fileInfo.Mode()
+		if fileMode.IsRegular() {
 			allFilePaths = append(allFilePaths, filePath)
 		}
 		return nil
@@ -180,6 +184,9 @@ func getBinary(filePaths []string, desiredBinaryRename, expectedBinaryHash strin
 	}
 
 	if desiredBinaryRename != "" {
+		if expectedBinaryHash != "" && expectedBinaryHash != executableFiles[0].fileHash {
+			return "", "", "", BinaryMismatchError{BinaryName: desiredBinaryRename}
+		}
 		return executableFiles[0].filePath, desiredBinaryRename, executableFiles[0].fileHash, nil
 	}
 	return executableFiles[0].filePath, executableFiles[0].fileName, executableFiles[0].fileHash, nil


### PR DESCRIPTION
Continuation of #42 

If you are installing from a lockfile, stew will now throw an error if the hash of the downloaded binary doesn't match the hash in the lockfile.