### PR TITLE
Exclude pre-releases from "latest tag" selection in install/upgrade

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -82,7 +82,13 @@ func installOne(pkg stew.PackageData, userOS, userArch string, systemInfo stew.S
 		}
 
 		if tag == "" || tag == "latest" {
-			tag = githubProject.Releases[0].TagName
+			// Find first non-prerelease tag
+			for _, release := range githubProject.Releases {
+				if !release.Prerelease {
+					tag = release.TagName
+					break
+				}
+			}
 		}
 
 		tagIndex, tagFound := stew.Contains(releaseTags, tag)

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -76,8 +76,13 @@ func upgradeOne(binaryName, userOS, userArch string, lockFile stew.LockFile, sys
 		return err
 	}
 
-	// Get the latest tag
+	// Start at the latest tag
 	tagIndex := 0
+	// Find first non-prerelease tag
+	for githubProject.Releases[tagIndex].Prerelease {
+		tagIndex += 1
+	}
+
 	tag := githubProject.Releases[tagIndex].TagName
 
 	if pkg.Tag == tag {

--- a/lib/github.go
+++ b/lib/github.go
@@ -21,8 +21,9 @@ type GithubAPIResponse []GithubRelease
 
 // GithubRelease contains information about a GitHub release, including the associated assets
 type GithubRelease struct {
-	TagName string        `json:"tag_name"`
-	Assets  []GithubAsset `json:"assets"`
+	TagName    string        `json:"tag_name"`
+	Assets     []GithubAsset `json:"assets"`
+	Prerelease bool          `json:"prerelease"`
 }
 
 // GithubAsset contains information about a specific GitHub asset


### PR DESCRIPTION
Closes https://github.com/marwanhawari/stew/issues/44.

Detect "pre-release" releases and default to installing/upgrading to the latest non-prerelease version.

## Install

Before

```
./stew install syncthing/syncthing
syncthing/syncthing
⬇️  Downloading asset: 100% |███████████| (11/11 MB, 3.3 MB/s)
✅ Downloaded syncthing-macos-arm64-v1.28.0-rc.3.zip to /Users/hugo/.local/share/stew/pkg
```

After

```
./stew install syncthing/syncthing
syncthing/syncthing
⬇️  Downloading asset: 100% |████████████| (10/10 MB, 12 MB/s)
✅ Downloaded syncthing-macos-arm64-v1.27.12.zip to /Users/hugo/.local/share/stew/pkg
```

## Upgrade

Note: syncthing 1.27.12 was installed before running "upgrade"

Before

```
./stew upgrade syncthing
syncthing
⬇️  Downloading asset: 100% |███████████| (11/11 MB, 9.6 MB/s)
✅ Downloaded syncthing-macos-arm64-v1.28.0-rc.3.zip to /Users/hugo/.local/share/stew/pkg
```

After

```
./stew upgrade syncthing
syncthing
Error: The latest tag v1.27.12 is already installed
```