### PR TITLE
Improve arch and system autodetection #52

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -23,16 +23,16 @@ var BoldColor = color.New(color.OpBold).Render
 var LoadingSpinner = spinner.New(spinner.CharSets[9], 100*time.Millisecond, spinner.WithColor("cyan"), spinner.WithHiddenCursor(true))
 
 // RegexDarwin is a regular express for darwin systems
-var RegexDarwin = `(?i)(darwin|mac(os)?|apple|osx)`
+var RegexDarwin = `(?i)(darwin|mac(os)?|apple|osx|.dmg)`
 
 // RegexWindows is a regular express for windows systems
-var RegexWindows = `(?i)(windows|win)`
+var RegexWindows = `(?i)(windows|win|.msi|.exe|.appx)`
 
 // RegexArm64 is a regular express for arm64 architectures
-var RegexArm64 = `(?i)(arm64|aarch64)`
+var RegexArm64 = `(?i)(arm64|aarch64|arm64e)`
 
 // RegexAmd64 is a regular express for amd64 architectures
-var RegexAmd64 = `(?i)(x86_64|amd64|x64)`
+var RegexAmd64 = `(?i)(x86_64|amd64|x64|amd64e)`
 
 // Regex386 is a regular express for 386 architectures
 var Regex386 = `(?i)(i?386|x86_32|amd32|x32)`

--- a/lib/github.go
+++ b/lib/github.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
-	"strings"
 
 	"github.com/marwanhawari/stew/constants"
 )
@@ -125,8 +124,10 @@ func assetsFound(releaseAssets []string, releaseTag string) error {
 
 func filterReleaseAssets(assets []string) []string {
 	var filteredAssets []string
+	re := regexp.MustCompile(`\.(sha(256|512)(sum)?)$`)
+
 	for _, asset := range assets {
-		if strings.HasSuffix(asset, ".sha256") {
+		if re.MatchString(asset) {
 			continue
 		}
 		filteredAssets = append(filteredAssets, asset)
@@ -152,6 +153,7 @@ func DetectAsset(userOS string, userArch string, releaseAssets []string) (string
 	}
 
 	filteredReleaseAssets := filterReleaseAssets(releaseAssets)
+
 	for _, asset := range filteredReleaseAssets {
 		if reOS.MatchString(asset) {
 			detectedOSAssets = append(detectedOSAssets, asset)
@@ -189,7 +191,7 @@ func DetectAsset(userOS string, userArch string, releaseAssets []string) (string
 			}
 		}
 		if finalAsset == "" {
-			finalAsset, err = WarningPromptSelect("Could not automatically detect the release asset matching your OS/Arch. Please select it manually:", filteredReleaseAssets)
+			finalAsset, err = WarningPromptSelect("Could not automatically detect the release asset matching your OS/Arch. Please select it manually:", detectedFinalAssets)
 			if err != nil {
 				return "", err
 			}


### PR DESCRIPTION
Before:
```bash
stew i rancher-sandbox/rancher-desktop
rancher-sandbox/rancher-desktop
! Could not automatically detect the release asset matching your OS/Arch. Please select it manually:  [Use arrows to move, type to filter]
> rancher-desktop-linux-v1.16.0.zip
  rancher-desktop-linux-v1.16.0.zip.sha512sum
  Rancher.Desktop-1.16.0-mac.aarch64.zip
  Rancher.Desktop-1.16.0-mac.aarch64.zip.sha512sum
  Rancher.Desktop-1.16.0-mac.x86_64.zip
  Rancher.Desktop-1.16.0-mac.x86_64.zip.sha512sum
  Rancher.Desktop-1.16.0.aarch64.dmg
```

After:
```bash
stew i rancher-sandbox/rancher-desktop
rancher-sandbox/rancher-desktop
! Could not automatically detect the release asset matching your OS/Arch. Please select it manually:  [Use arrows to move, type to filter]
> Rancher.Desktop-1.16.0-mac.x86_64.zip
  Rancher.Desktop-1.16.0.x86_64.dmg
```

```bash
uname -a
Darwin m 24.0.0 Darwin Kernel Version 24.0.0: Tue Sep 24 23:37:13 PDT 2024; root:xnu-11215.1.12~1/RELEASE_ARM64_T8112 x86_64
```