### PR TITLE
feat: allow for GitHub extended search syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ stew install Stewfile.lock.json
 ```sh
 # Search for a GitHub repo and browse its contents with a terminal UI
 stew search ripgrep
+stew search fzf user:junegunn language:go    # Use GitHub search syntax
 ```
 
 ### Browse

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -1,22 +1,29 @@
 package cmd
 
 import (
+	"net/url"
+	"strings"
+
 	"github.com/marwanhawari/stew/constants"
 	stew "github.com/marwanhawari/stew/lib"
 )
 
 // Search is executed when you run `stew search`
-func Search(cliInput string) {
+func Search(cliInput []string) {
 	sp := constants.LoadingSpinner
 
-	err := stew.ValidateCLIInput(cliInput)
-	stew.CatchAndExit(err)
+	if len(cliInput) == 0 {
+		stew.CatchAndExit(stew.EmptyCLIInputError{})
+	}
+	for _, input := range cliInput {
+		err := stew.ValidateGithubSearchQuery(input)
+		stew.CatchAndExit(err)
+	}
 
-	err = stew.ValidateGithubSearchQuery(cliInput)
-	stew.CatchAndExit(err)
+	searchQuery := url.QueryEscape(strings.Join(cliInput, " "))
 
 	sp.Start()
-	githubSearch, err := stew.NewGithubSearch(cliInput)
+	githubSearch, err := stew.NewGithubSearch(searchQuery)
 	sp.Stop()
 	stew.CatchAndExit(err)
 

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -41,7 +41,7 @@ var Regex386 = `(?i)(i?386|x86_32|amd32|x32)`
 var RegexGithub = `(?i)^[A-Za-z0-9\-]+\/[A-Za-z0-9\_\.\-]+(@.+)?$`
 
 // RegexGithubSearch is a regular express for valid GitHub search queries
-var RegexGithubSearch = `(?i)^[A-Za-z0-9\_\.\-\/]+$`
+var RegexGithubSearch = `(?i)^[A-Za-z0-9\_\.\-\/\:]+$`
 
 // RegexURL is a regular express for valid URLs
 var RegexURL = `(http|ftp|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])`

--- a/lib/github_test.go
+++ b/lib/github_test.go
@@ -562,7 +562,7 @@ var testGithubSearchReadJSON GithubSearch = GithubSearch{
 	Items: []GithubSearchResult{
 		{
 			FullName:    "marwanhawari/ppath",
-			Stars:       7,
+			Stars:       8,
 			Language:    "Go",
 			Description: "🌈 A command-line tool to pretty print your system's PATH environment variable.",
 		},
@@ -575,14 +575,14 @@ var testGithubSearch GithubSearch = GithubSearch{
 	Items: []GithubSearchResult{
 		{
 			FullName:    "marwanhawari/ppath",
-			Stars:       7,
+			Stars:       8,
 			Language:    "Go",
 			Description: "🌈 A command-line tool to pretty print your system's PATH environment variable.",
 		},
 	},
 }
 
-var testFormattedSearchResults = []string{"marwanhawari/ppath [⭐️7] 🌈 A command-line tool to pretty print your system's PATH environment variable."}
+var testFormattedSearchResults = []string{"marwanhawari/ppath [⭐️8] 🌈 A command-line tool to pretty print your system's PATH environment variable."}
 
 func Test_getGithubSearchJSON(t *testing.T) {
 	type args struct {

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ func main() {
 				Usage:   "Search for a GitHub repo then browse the selected repo's releases and assets. [Ex: stew search ripgrep]",
 				Aliases: []string{"s"},
 				Action: func(c *cli.Context) error {
-					cmd.Search(c.Args().First())
+					cmd.Search(c.Args())
 					return nil
 				},
 			},


### PR DESCRIPTION
closes #56 

- [x] Allow multi-word search queries
- [x] Allow the `:` character in search queries to allow users to use the GitHub search syntax (`user:marwanhawari`, `language:python`)