### PR TITLE
Add binary to list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 * No need for `sudo`.
 * Just a single binary with 0 dependencies.
 * Portable [`Stewfile`](https://github.com/marwanhawari/stew/blob/main/examples/Stewfile) with optional pinned versioning.
-* Headless batch installs from a `Stewfile.lock.json` file.
+* Headless batch installs from a [`Stewfile.lock.json`](https://github.com/marwanhawari/stew/blob/main/examples/Stewfile.lock.json) file.
 
 ![demo](https://github.com/marwanhawari/stew/raw/main/assets/demo.gif)
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/marwanhawari/stew/constants"
 	stew "github.com/marwanhawari/stew/lib"
 )
 
@@ -26,10 +27,11 @@ func List(cliTagsFlag bool) {
 		case "other":
 			fmt.Println(pkg.URL)
 		case "github":
+			defaultLine := pkg.Owner + "/" + pkg.Repo + constants.GreenColor(":"+pkg.Binary)
 			if cliTagsFlag {
-				fmt.Println(pkg.Owner + "/" + pkg.Repo + "@" + pkg.Tag)
+				fmt.Println(defaultLine + constants.CyanColor("@"+pkg.Tag))
 			} else {
-				fmt.Println(pkg.Owner + "/" + pkg.Repo)
+				fmt.Println(defaultLine)
 			}
 		}
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -25,7 +25,7 @@ func List(cliTagsFlag bool) {
 	for _, pkg := range lockFile.Packages {
 		switch pkg.Source {
 		case "other":
-			fmt.Println(pkg.URL)
+			fmt.Println(pkg.URL + constants.GreenColor(":"+pkg.Binary))
 		case "github":
 			defaultLine := pkg.Owner + "/" + pkg.Repo + constants.GreenColor(":"+pkg.Binary)
 			if cliTagsFlag {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -2,13 +2,19 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
+	"github.com/gookit/color"
 	"github.com/marwanhawari/stew/constants"
 	stew "github.com/marwanhawari/stew/lib"
+	"golang.org/x/term"
 )
 
 // List is executed when you run `stew list`
 func List(cliTagsFlag bool) {
+	if !term.IsTerminal(int(os.Stdout.Fd())) {
+		color.Disable()
+	}
 
 	userOS, userArch, _, systemInfo, err := stew.Initialize()
 	stew.CatchAndExit(err)
@@ -25,11 +31,11 @@ func List(cliTagsFlag bool) {
 	for _, pkg := range lockFile.Packages {
 		switch pkg.Source {
 		case "other":
-			fmt.Println(pkg.URL + constants.GreenColor(":"+pkg.Binary))
+			fmt.Println(constants.GreenColor(pkg.Binary+":") + pkg.URL)
 		case "github":
-			defaultLine := pkg.Owner + "/" + pkg.Repo + constants.GreenColor(":"+pkg.Binary)
+			defaultLine := constants.GreenColor(pkg.Binary+":") + pkg.Owner + "/" + pkg.Repo
 			if cliTagsFlag {
-				fmt.Println(defaultLine + constants.CyanColor("@"+pkg.Tag))
+				fmt.Println(defaultLine + "@" + pkg.Tag)
 			} else {
 				fmt.Println(defaultLine)
 			}

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -16,6 +16,9 @@ var GreenColor = color.New(color.FgGreen, color.OpBold).Render
 // YellowColor makes text yellow
 var YellowColor = color.New(color.FgYellow, color.OpBold).Render
 
+// CyanColor makes text cyan
+var CyanColor = color.New(color.FgCyan, color.OpBold).Render
+
 // BoldColor makes text bold
 var BoldColor = color.New(color.OpBold).Render
 

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -16,9 +16,6 @@ var GreenColor = color.New(color.FgGreen, color.OpBold).Render
 // YellowColor makes text yellow
 var YellowColor = color.New(color.FgYellow, color.OpBold).Render
 
-// CyanColor makes text cyan
-var CyanColor = color.New(color.FgCyan, color.OpBold).Render
-
 // BoldColor makes text bold
 var BoldColor = color.New(color.OpBold).Render
 
@@ -47,7 +44,7 @@ var RegexGithub = `(?i)^[A-Za-z0-9\-]+\/[A-Za-z0-9\_\.\-]+(@.+)?$`
 var RegexGithubSearch = `(?i)^[A-Za-z0-9\_\.\-\/\:]+$`
 
 // RegexURL is a regular express for valid URLs
-var RegexURL = `(http|ftp|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])`
+var RegexURL = `^(http|ftp|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])`
 
 // RegexChecksum is a regular expression for matching checksum files
 var RegexChecksum = `\.(sha(256|512)(sum)?)$`

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/mholt/archiver v3.1.1+incompatible
 	github.com/schollz/progressbar/v3 v3.14.2
 	github.com/urfave/cli v1.22.14
+	golang.org/x/term v0.19.0
 )
 
 require (
@@ -31,6 +32,5 @@ require (
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sys v0.19.0 // indirect
-	golang.org/x/term v0.19.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 )

--- a/lib/util.go
+++ b/lib/util.go
@@ -221,10 +221,10 @@ func ParseCLIInput(cliInput string) (PackageData, error) {
 	var parsedInput PackageData
 	if reGithub.MatchString(cliInput) {
 		parsedInput, err = parseGithubInput(cliInput)
-	} else if len(splitCliInput) == 2 && reGithub.MatchString(splitCliInput[1]) {
-		parsedInput, err = parseGithubInput(splitCliInput[1])
 	} else if reURL.MatchString(cliInput) {
 		parsedInput, err = parseURLInput(cliInput)
+	} else if len(splitCliInput) == 2 && reGithub.MatchString(splitCliInput[1]) {
+		parsedInput, err = parseGithubInput(splitCliInput[1])
 	} else if len(splitCliInput) == 2 && reURL.MatchString(splitCliInput[1]) {
 		parsedInput, err = parseURLInput(splitCliInput[1])
 	} else {

--- a/lib/util.go
+++ b/lib/util.go
@@ -215,11 +215,18 @@ func ParseCLIInput(cliInput string) (PackageData, error) {
 	if err != nil {
 		return PackageData{}, err
 	}
+
+	splitCliInput := strings.SplitN(cliInput, ":", 2)
+
 	var parsedInput PackageData
 	if reGithub.MatchString(cliInput) {
 		parsedInput, err = parseGithubInput(cliInput)
+	} else if len(splitCliInput) == 2 && reGithub.MatchString(splitCliInput[1]) {
+		parsedInput, err = parseGithubInput(splitCliInput[1])
 	} else if reURL.MatchString(cliInput) {
 		parsedInput, err = parseURLInput(cliInput)
+	} else if len(splitCliInput) == 2 && reURL.MatchString(splitCliInput[1]) {
+		parsedInput, err = parseURLInput(splitCliInput[1])
 	} else {
 		return PackageData{}, UnrecognizedInputError{}
 	}

--- a/lib/util_test.go
+++ b/lib/util_test.go
@@ -465,6 +465,38 @@ func TestParseCLIInput(t *testing.T) {
 			want:    PackageData{},
 			wantErr: true,
 		},
+		{
+			name: "test5",
+			args: args{
+				cliInput: "a/b/c",
+			},
+			want:    PackageData{},
+			wantErr: true,
+		},
+		{
+			name: "test6",
+			args: args{
+				cliInput: "ppath:marwanhawari/ppath",
+			},
+			want: PackageData{
+				Source: "github",
+				Owner:  "marwanhawari",
+				Repo:   "ppath",
+			},
+			wantErr: false,
+		},
+		{
+			name: "test7",
+			args: args{
+				cliInput: "ppath:https://github.com/marwanhawari/ppath/releases/download/v0.0.3/ppath-v0.0.3-darwin-arm64.tar.gz",
+			},
+			want: PackageData{
+				Source: "other",
+				Asset:  "ppath-v0.0.3-darwin-arm64.tar.gz",
+				URL:    "https://github.com/marwanhawari/ppath/releases/download/v0.0.3/ppath-v0.0.3-darwin-arm64.tar.gz",
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This PR modifies the `stew ls` output to include the binary. The format is now: `<binaryName>:<owner>/<repo>` for GitHub installs and `<binaryName>:<URL>` for URL installs.

Old Stewfile versions will work with the new stew version (>=0.6.0), but new Stewfile versions will not work with old versions of stew (<0.6.0).

Example output before:
<img width="695" alt="Screenshot 2025-04-25 at 12 20 29 AM" src="https://github.com/user-attachments/assets/8f6331ea-cc15-4bc2-8f6b-0a29714b92b8" />

After:
<img width="747" alt="Screenshot 2025-04-25 at 12 21 02 AM" src="https://github.com/user-attachments/assets/31ff7740-ee78-4a17-b9b9-8238b00da899" />


closes #67 
