### PR TITLE
Improve automatic and manual asset selection

### DIFF
--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -50,7 +50,9 @@ func Browse(cliInput string) {
 
 	releaseAssets, err := stew.GetGithubReleasesAssets(githubProject, tag)
 	stew.CatchAndExit(err)
-	asset, err := stew.PromptSelect("Download and install an asset", releaseAssets)
+	filteredReleaseAssets, err := stew.FilterReleaseAssets(releaseAssets, tag)
+	stew.CatchAndExit(err)
+	asset, err := stew.PromptSelect("Download and install an asset", filteredReleaseAssets)
 	stew.CatchAndExit(err)
 	assetIndex, _ := stew.Contains(releaseAssets, asset)
 

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Install is executed when you run `stew install`
-func Install(cliInput string) {
+func Install(showAllAssets bool, cliInput string) {
 	userOS, userArch, _, systemInfo, err := stew.Initialize()
 	stew.CatchAndExit(err)
 
@@ -32,12 +32,12 @@ func Install(cliInput string) {
 	} else {
 		pkg, err := stew.ParseCLIInput(cliInput)
 		stew.CatchAndExit(err)
-		err = installOne(pkg, userOS, userArch, systemInfo, false)
+		err = installOne(pkg, userOS, userArch, systemInfo, false, showAllAssets)
 		stew.CatchAndExit(err)
 	}
 }
 
-func installOne(pkg stew.PackageData, userOS, userArch string, systemInfo stew.SystemInfo, installingFromLockFile bool) error {
+func installOne(pkg stew.PackageData, userOS, userArch string, systemInfo stew.SystemInfo, installingFromLockFile bool, showAllAssets bool) error {
 	sp := constants.LoadingSpinner
 
 	stewBinPath := systemInfo.StewBinPath
@@ -106,7 +106,7 @@ func installOne(pkg stew.PackageData, userOS, userArch string, systemInfo stew.S
 		}
 
 		if asset == "" {
-			asset, err = stew.DetectAsset(userOS, userArch, releaseAssets)
+			asset, err = stew.DetectAsset(userOS, userArch, releaseAssets, showAllAssets)
 		}
 		if err != nil {
 			return err
@@ -184,7 +184,7 @@ func installOne(pkg stew.PackageData, userOS, userArch string, systemInfo stew.S
 
 func installFromLockFile(pkgs []stew.PackageData, userOS, userArch string, systemInfo stew.SystemInfo) error {
 	for _, pkg := range pkgs {
-		err := installOne(pkg, userOS, userArch, systemInfo, true)
+		err := installOne(pkg, userOS, userArch, systemInfo, true, false)
 		if err != nil {
 			return err
 		}
@@ -194,7 +194,7 @@ func installFromLockFile(pkgs []stew.PackageData, userOS, userArch string, syste
 
 func installFromStewfile(pkgs []stew.PackageData, userOS, userArch string, systemInfo stew.SystemInfo) {
 	for _, pkg := range pkgs {
-		err := installOne(pkg, userOS, userArch, systemInfo, false)
+		err := installOne(pkg, userOS, userArch, systemInfo, false, false)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			continue

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -114,7 +114,11 @@ func installOne(pkg stew.PackageData, userOS, userArch string, systemInfo stew.S
 
 		assetIndex, assetFound := stew.Contains(releaseAssets, asset)
 		if !assetFound {
-			asset, err = stew.WarningPromptSelect(fmt.Sprintf("Could not find the asset %v - please select an asset:", constants.YellowColor(asset)), releaseAssets)
+			filteredReleaseAssets, err := stew.FilterReleaseAssets(releaseAssets, tag)
+			if err != nil {
+				return err
+			}
+			asset, err = stew.WarningPromptSelect(fmt.Sprintf("Could not find the asset %v - please select an asset:", constants.YellowColor(asset)), filteredReleaseAssets)
 			if err != nil {
 				return err
 			}

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Search is executed when you run `stew search`
-func Search(cliInput []string) {
+func Search(showAllAssets bool, cliInput []string) {
 	sp := constants.LoadingSpinner
 
 	if len(cliInput) == 0 {
@@ -38,6 +38,6 @@ func Search(cliInput []string) {
 
 	searchResultIndex, _ := stew.Contains(formattedSearchResults, githubProjectName)
 
-	Install(githubSearch.Items[searchResultIndex].FullName)
+	Install(showAllAssets, githubSearch.Items[searchResultIndex].FullName)
 
 }

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Upgrade is executed when you run `stew upgrade`
-func Upgrade(upgradeAllCliFlag bool, binaryName string) {
+func Upgrade(upgradeAllCliFlag bool, showAllAssets bool, binaryName string) {
 
 	userOS, userArch, stewConfig, systemInfo, err := stew.Initialize()
 	stew.CatchAndExit(err)
@@ -40,12 +40,12 @@ func Upgrade(upgradeAllCliFlag bool, binaryName string) {
 	if upgradeAllCliFlag {
 		upgradeAll(userOS, userArch, lockFile, systemInfo, stewConfig)
 	} else {
-		err := upgradeOne(binaryName, userOS, userArch, lockFile, systemInfo)
+		err := upgradeOne(binaryName, userOS, userArch, lockFile, systemInfo, showAllAssets)
 		stew.CatchAndExit(err)
 	}
 }
 
-func upgradeOne(binaryName, userOS, userArch string, lockFile stew.LockFile, systemInfo stew.SystemInfo) error {
+func upgradeOne(binaryName, userOS, userArch string, lockFile stew.LockFile, systemInfo stew.SystemInfo, showAllAssets bool) error {
 	sp := constants.LoadingSpinner
 	stewPkgPath := systemInfo.StewPkgPath
 	stewLockFilePath := systemInfo.StewLockFilePath
@@ -95,7 +95,7 @@ func upgradeOne(binaryName, userOS, userArch string, lockFile stew.LockFile, sys
 		return err
 	}
 
-	asset, err := stew.DetectAsset(userOS, userArch, releaseAssets)
+	asset, err := stew.DetectAsset(userOS, userArch, releaseAssets, showAllAssets)
 	if err != nil {
 		return err
 	}
@@ -134,7 +134,7 @@ func upgradeAll(userOS, userArch string, lockFile stew.LockFile, systemInfo stew
 			fmt.Printf("%v (Excluded)\n", constants.YellowColor(pkg.Binary))
 			continue
 		}
-		if err := upgradeOne(pkg.Binary, userOS, userArch, lockFile, systemInfo); err != nil {
+		if err := upgradeOne(pkg.Binary, userOS, userArch, lockFile, systemInfo, false); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			continue
 		}

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -37,6 +37,12 @@ var RegexAmd64 = `(?i)(x86_64|amd64|x64|amd64e)`
 // Regex386 is a regular express for 386 architectures
 var Regex386 = `(?i)(i?386|x86_32|amd32|x32)`
 
+// RegexLinuxGnu is a regex for Linux gnu libc binaries
+var RegexLinuxGnu = `(?i)gnu`
+
+// RegexLinuxMusl is a regex for Linux musl libc binaries
+var RegexLinuxMusl = `(?i)musl`
+
 // RegexGithub is a regular express for valid GitHub repos
 var RegexGithub = `(?i)^[A-Za-z0-9\-]+\/[A-Za-z0-9\_\.\-]+(@.+)?$`
 

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -55,6 +55,9 @@ var RegexURL = `^(http|ftp|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:\/
 // RegexChecksum is a regular expression for matching checksum files
 var RegexChecksum = `\.(sha(256|512)(sum)?)$`
 
+// RegexPackageInstaller is a regular expression for matching package-manager and installer assets
+var RegexPackageInstaller = `(?i)(\.deb|\.rpm|\.apk|\.msi|\.pkg|\.dmg|\.pkg\.tar\.(gz|xz|zst))$`
+
 // StewOwner is the username of the stew github repo owner
 var StewOwner = `marwanhawari`
 

--- a/lib/errors.go
+++ b/lib/errors.go
@@ -34,6 +34,18 @@ func (e AssetsNotFoundError) Error() string {
 	return fmt.Sprintf("%v Could not find any assets for release %v", constants.RedColor("Error:"), constants.RedColor(e.Tag))
 }
 
+// PortableAssetsNotFoundError occurs if only package-manager or installer assets are found for a GitHub release
+type PortableAssetsNotFoundError struct {
+	Tag string
+}
+
+func (e PortableAssetsNotFoundError) Error() string {
+	if e.Tag == "" {
+		return fmt.Sprintf("%v No portable release assets were found. Only package-manager or installer artifacts are available, and stew filters those out", constants.RedColor("Error:"))
+	}
+	return fmt.Sprintf("%v No portable release assets were found for release %v. Only package-manager or installer artifacts are available, and stew filters those out", constants.RedColor("Error:"), constants.RedColor(e.Tag))
+}
+
 // NoPackagesInLockfileError occurs if you try to remove packages from a lockfile without any packages
 type NoPackagesInLockfileError struct {
 }

--- a/lib/errors_test.go
+++ b/lib/errors_test.go
@@ -98,6 +98,32 @@ func TestAssetsNotFoundError_Error(t *testing.T) {
 	}
 }
 
+func TestPortableAssetsNotFoundError_Error(t *testing.T) {
+	tests := []struct {
+		name string
+		err  PortableAssetsNotFoundError
+		want string
+	}{
+		{
+			name: "with tag",
+			err:  PortableAssetsNotFoundError{Tag: "testTag"},
+			want: fmt.Sprintf("%v No portable release assets were found for release %v. Only package-manager or installer artifacts are available, and stew filters those out", constants.RedColor("Error:"), constants.RedColor("testTag")),
+		},
+		{
+			name: "without tag",
+			err:  PortableAssetsNotFoundError{},
+			want: fmt.Sprintf("%v No portable release assets were found. Only package-manager or installer artifacts are available, and stew filters those out", constants.RedColor("Error:")),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.want {
+				t.Errorf("PortableAssetsNotFoundError.Error() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNoPackagesInLockfileError_Error(t *testing.T) {
 	tests := []struct {
 		name string

--- a/lib/github.go
+++ b/lib/github.go
@@ -195,7 +195,20 @@ func DetectAsset(userOS string, userArch string, releaseAssets []string) (string
 			}
 		}
 		if finalAsset == "" {
-			finalAsset, err = WarningPromptSelect("Could not automatically detect the release asset matching your OS/Arch. Please select it manually:", filteredReleaseAssets)
+			// Determine which assets to show in manual selection
+			var assetsForManualSelection []string
+			if len(detectedFinalAssets) > 1 {
+				// Multiple OS+arch matches, show only those
+				assetsForManualSelection = detectedFinalAssets
+			} else if len(detectedOSAssets) > 0 {
+				// OS matched but no arch match, show OS-matched assets
+				assetsForManualSelection = detectedOSAssets
+			} else {
+				// No matches at all, show checksum-filtered list
+				assetsForManualSelection = filteredReleaseAssets
+			}
+			
+			finalAsset, err = WarningPromptSelect("Could not automatically detect the release asset matching your OS/Arch. Please select it manually:", assetsForManualSelection)
 			if err != nil {
 				return "", err
 			}

--- a/lib/github.go
+++ b/lib/github.go
@@ -129,10 +129,11 @@ func assetsFound(releaseAssets []string, releaseTag string) error {
 
 func filterReleaseAssets(assets []string) []string {
 	var filteredAssets []string
-	re := regexp.MustCompile(constants.RegexChecksum)
+	reChecksum := regexp.MustCompile(constants.RegexChecksum)
+	rePackageInstaller := regexp.MustCompile(constants.RegexPackageInstaller)
 
 	for _, asset := range assets {
-		if re.MatchString(asset) {
+		if reChecksum.MatchString(asset) || rePackageInstaller.MatchString(asset) {
 			continue
 		}
 		filteredAssets = append(filteredAssets, asset)
@@ -140,12 +141,24 @@ func filterReleaseAssets(assets []string) []string {
 	return filteredAssets
 }
 
+func FilterReleaseAssets(assets []string, releaseTag string) ([]string, error) {
+	filteredAssets := filterReleaseAssets(assets)
+	if len(filteredAssets) == 0 {
+		return nil, PortableAssetsNotFoundError{Tag: releaseTag}
+	}
+	return filteredAssets, nil
+}
+
 // DetectAsset will automatically detect a release asset matching your systems OS/arch or prompt you to manually select an asset.
-// If bypassDetection is true, automatic detection is skipped and the user is shown all available assets (excluding checksums).
+// If bypassDetection is true, automatic detection is skipped and the user is shown all available assets (excluding checksums and installers).
 func DetectAsset(userOS string, userArch string, releaseAssets []string, bypassDetection bool) (string, error) {
+	filteredReleaseAssets, err := FilterReleaseAssets(releaseAssets, "")
+	if err != nil {
+		return "", err
+	}
+
 	// If bypassDetection is true, skip all detection and show manual selection with all assets
 	if bypassDetection {
-		filteredReleaseAssets := filterReleaseAssets(releaseAssets)
 		finalAsset, err := WarningPromptSelect("Showing all available release assets. Please select one:", filteredReleaseAssets)
 		if err != nil {
 			return "", err
@@ -155,7 +168,6 @@ func DetectAsset(userOS string, userArch string, releaseAssets []string, bypassD
 	
 	var detectedOSAssets []string
 	var reOS *regexp.Regexp
-	var err error
 	switch userOS {
 	case "darwin":
 		reOS, err = regexp.Compile(constants.RegexDarwin)
@@ -168,7 +180,6 @@ func DetectAsset(userOS string, userArch string, releaseAssets []string, bypassD
 		return "", err
 	}
 
-	filteredReleaseAssets := filterReleaseAssets(releaseAssets)
 	for _, asset := range filteredReleaseAssets {
 		if reOS.MatchString(asset) {
 			detectedOSAssets = append(detectedOSAssets, asset)

--- a/lib/github.go
+++ b/lib/github.go
@@ -140,8 +140,19 @@ func filterReleaseAssets(assets []string) []string {
 	return filteredAssets
 }
 
-// DetectAsset will automatically detect a release asset matching your systems OS/arch or prompt you to manually select an asset
-func DetectAsset(userOS string, userArch string, releaseAssets []string) (string, error) {
+// DetectAsset will automatically detect a release asset matching your systems OS/arch or prompt you to manually select an asset.
+// If bypassDetection is true, automatic detection is skipped and the user is shown all available assets (excluding checksums).
+func DetectAsset(userOS string, userArch string, releaseAssets []string, bypassDetection bool) (string, error) {
+	// If bypassDetection is true, skip all detection and show manual selection with all assets
+	if bypassDetection {
+		filteredReleaseAssets := filterReleaseAssets(releaseAssets)
+		finalAsset, err := WarningPromptSelect("Showing all available release assets. Please select one:", filteredReleaseAssets)
+		if err != nil {
+			return "", err
+		}
+		return finalAsset, nil
+	}
+	
 	var detectedOSAssets []string
 	var reOS *regexp.Regexp
 	var err error

--- a/lib/github.go
+++ b/lib/github.go
@@ -204,6 +204,12 @@ func DetectAsset(userOS string, userArch string, releaseAssets []string, bypassD
 			if err != nil {
 				return "", err
 			}
+		} else if userOS == "linux" && len(detectedFinalAssets) > 1 {
+			// Apply gnu/musl preference for Linux when multiple assets match
+			finalAsset, err = linuxGnuMuslPreference(detectedFinalAssets)
+			if err != nil {
+				return "", err
+			}
 		}
 		if finalAsset == "" {
 			// Determine which assets to show in manual selection
@@ -249,6 +255,62 @@ func darwinARMFallback(darwinAssets []string) (string, error) {
 	}
 
 	return altAssets[0], nil
+}
+
+// linuxGnuMuslPreference applies gnu/musl preference for Linux assets
+// Returns the preferred asset or empty string if preference cannot be determined
+func linuxGnuMuslPreference(linuxAssets []string) (string, error) {
+	reGnu, err := regexp.Compile(constants.RegexLinuxGnu)
+	if err != nil {
+		return "", err
+	}
+
+	reMusl, err := regexp.Compile(constants.RegexLinuxMusl)
+	if err != nil {
+		return "", err
+	}
+
+	// Separate assets by type
+	var gnuAssets []string
+	var muslAssets []string
+	var unspecifiedAssets []string
+
+	for _, asset := range linuxAssets {
+		if reMusl.MatchString(asset) {
+			muslAssets = append(muslAssets, asset)
+		} else if reGnu.MatchString(asset) {
+			gnuAssets = append(gnuAssets, asset)
+		} else {
+			unspecifiedAssets = append(unspecifiedAssets, asset)
+		}
+	}
+
+	// Apply preference: gnu > unspecified (assumed gnu) > musl
+	if len(gnuAssets) == 1 {
+		return gnuAssets[0], nil
+	}
+	if len(gnuAssets) > 1 {
+		// Multiple gnu assets, can't auto-select, return empty for manual selection
+		return "", nil
+	}
+	if len(unspecifiedAssets) == 1 {
+		// Unspecified assets are assumed to be gnu, prefer over musl
+		return unspecifiedAssets[0], nil
+	}
+	if len(unspecifiedAssets) > 1 {
+		// Multiple unspecified assets, can't auto-select
+		return "", nil
+	}
+	if len(muslAssets) == 1 {
+		return muslAssets[0], nil
+	}
+	if len(muslAssets) > 1 {
+		// Multiple musl assets, can't auto-select
+		return "", nil
+	}
+
+	// Zero assets - trigger manual selection
+	return "", nil
 }
 
 // GithubSearch contains information about the GitHub search including the GitHub search results

--- a/lib/github_test.go
+++ b/lib/github_test.go
@@ -499,6 +499,57 @@ func TestDetectAsset(t *testing.T) {
 			want:    "ppath-v0.0.1-windows-unexpectedArch.tar.gz",
 			wantErr: false,
 		},
+		{
+			name: "linux-multiple-assets-prefers-gnu",
+			args: args{
+				userOS:        "linux",
+				userArch:      "amd64",
+				releaseAssets: []string{
+					"program-v1.0.0-linux-amd64-gnu.tar.gz",
+					"program-v1.0.0-linux-amd64-musl.tar.gz",
+				},
+			},
+			want:    "program-v1.0.0-linux-amd64-gnu.tar.gz",
+			wantErr: false,
+		},
+		{
+			name: "linux-multiple-assets-fallback-unspecified-over-musl",
+			args: args{
+				userOS:        "linux",
+				userArch:      "amd64",
+				releaseAssets: []string{
+					"program-v1.0.0-linux-amd64-musl.tar.gz",
+					"program-v1.0.0-linux-amd64.tar.gz",
+				},
+			},
+			want:    "program-v1.0.0-linux-amd64.tar.gz",
+			wantErr: false,
+		},
+		{
+			name: "linux-multiple-assets-fallback-unspecified",
+			args: args{
+				userOS:        "linux",
+				userArch:      "amd64",
+				releaseAssets: []string{
+					"program-v1.0.0-linux-amd64.tar.gz",
+				},
+			},
+			want:    "program-v1.0.0-linux-amd64.tar.gz",
+			wantErr: false,
+		},
+		{
+			name: "linux-multiple-gnu-assets-triggers-manual",
+			args: args{
+				userOS:        "linux",
+				userArch:      "amd64",
+				releaseAssets: []string{
+					"program-v1.0.0-linux-amd64-gnu.tar.gz",
+					"program-v1.0.0-linux-amd64-gnu-static.tar.gz",
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -550,6 +601,99 @@ func Test_darwinARMFallback(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("darwinARMFallback() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_linuxGnuMuslPreference(t *testing.T) {
+	type args struct {
+		linuxAssets []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "single gnu asset",
+			args: args{
+				linuxAssets: []string{"program-linux-amd64-gnu.tar.gz"},
+			},
+			want:    "program-linux-amd64-gnu.tar.gz",
+			wantErr: false,
+		},
+		{
+			name: "prefers gnu over musl",
+			args: args{
+				linuxAssets: []string{
+					"program-linux-amd64-gnu.tar.gz",
+					"program-linux-amd64-musl.tar.gz",
+				},
+			},
+			want:    "program-linux-amd64-gnu.tar.gz",
+			wantErr: false,
+		},
+		{
+			name: "prefers unspecified over musl",
+			args: args{
+				linuxAssets: []string{
+					"program-linux-amd64-musl.tar.gz",
+					"program-linux-amd64.tar.gz",
+				},
+			},
+			want:    "program-linux-amd64.tar.gz",
+			wantErr: false,
+		},
+		{
+			name: "unspecified when no gnu or musl",
+			args: args{
+				linuxAssets: []string{"program-linux-amd64.tar.gz"},
+			},
+			want:    "program-linux-amd64.tar.gz",
+			wantErr: false,
+		},
+		{
+			name: "empty when multiple gnu",
+			args: args{
+				linuxAssets: []string{
+					"program-linux-amd64-gnu.tar.gz",
+					"program-linux-amd64-gnu-static.tar.gz",
+				},
+			},
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name: "empty when multiple musl",
+			args: args{
+				linuxAssets: []string{
+					"program-linux-amd64-musl.tar.gz",
+					"program-linux-amd64-musl-static.tar.gz",
+				},
+			},
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name: "empty when zero assets",
+			args: args{
+				linuxAssets: []string{},
+			},
+			want:    "",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := linuxGnuMuslPreference(tt.args.linuxAssets)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("linuxGnuMuslPreference() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("linuxGnuMuslPreference() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/lib/github_test.go
+++ b/lib/github_test.go
@@ -417,6 +417,75 @@ func Test_assetsFound(t *testing.T) {
 	}
 }
 
+func Test_filterReleaseAssets(t *testing.T) {
+	tests := []struct {
+		name   string
+		assets []string
+		want   []string
+	}{
+		{
+			name: "filters checksums and installer assets",
+			assets: []string{
+				"program-linux-amd64.tar.gz",
+				"program-linux-amd64.deb",
+				"program-linux-amd64.rpm",
+				"program-linux-amd64.apk",
+				"program-macos.pkg",
+				"program-macos.dmg",
+				"program.pkg.tar.zst",
+				"program.exe",
+				"program.sha256",
+			},
+			want: []string{"program-linux-amd64.tar.gz", "program.exe"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterReleaseAssets(tt.assets)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("filterReleaseAssets() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterReleaseAssets(t *testing.T) {
+	tests := []struct {
+		name       string
+		assets      []string
+		releaseTag string
+		want       []string
+		wantErr    bool
+	}{
+		{
+			name:       "returns filtered assets",
+			assets:      []string{"program-linux-amd64.tar.gz", "program-linux-amd64.deb"},
+			releaseTag: "v1.0.0",
+			want:       []string{"program-linux-amd64.tar.gz"},
+			wantErr:    false,
+		},
+		{
+			name:       "errors when only installers remain",
+			assets:      []string{"program-linux-amd64.deb", "program-linux-amd64.rpm"},
+			releaseTag: "v1.0.0",
+			want:       nil,
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := FilterReleaseAssets(tt.assets, tt.releaseTag)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FilterReleaseAssets() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FilterReleaseAssets() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDetectAsset(t *testing.T) {
 	type args struct {
 		userOS        string
@@ -536,6 +605,33 @@ func TestDetectAsset(t *testing.T) {
 			},
 			want:    "program-v1.0.0-linux-amd64.tar.gz",
 			wantErr: false,
+		},
+		{
+			name: "linux-ignores-installer-assets",
+			args: args{
+				userOS:   "linux",
+				userArch: "amd64",
+				releaseAssets: []string{
+					"program-v1.0.0-linux-amd64.deb",
+					"program-v1.0.0-linux-amd64.rpm",
+					"program-v1.0.0-linux-amd64.tar.gz",
+				},
+			},
+			want:    "program-v1.0.0-linux-amd64.tar.gz",
+			wantErr: false,
+		},
+		{
+			name: "errors when only installer assets exist",
+			args: args{
+				userOS:   "linux",
+				userArch: "amd64",
+				releaseAssets: []string{
+					"program-v1.0.0-linux-amd64.deb",
+					"program-v1.0.0-linux-amd64.rpm",
+				},
+			},
+			want:    "",
+			wantErr: true,
 		},
 		{
 			name: "linux-multiple-gnu-assets-triggers-manual",

--- a/lib/github_test.go
+++ b/lib/github_test.go
@@ -502,7 +502,7 @@ func TestDetectAsset(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := DetectAsset(tt.args.userOS, tt.args.userArch, tt.args.releaseAssets)
+			got, err := DetectAsset(tt.args.userOS, tt.args.userArch, tt.args.releaseAssets, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DetectAsset() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/main.go
+++ b/main.go
@@ -18,8 +18,14 @@ func main() {
 				Name:    "install",
 				Usage:   "Install a binary. The input can be a GitHub repo or a URL. [Ex: stew install marwanhawari/ppath]",
 				Aliases: []string{"i"},
+				Flags: []cli.Flag{
+					&cli.BoolFlag{
+						Name:  "show-all-assets",
+						Usage: "Show all available assets instead of auto-detecting based on OS/Arch",
+					},
+				},
 				Action: func(c *cli.Context) error {
-					cmd.Install(c.Args().First())
+					cmd.Install(c.Bool("show-all-assets"), c.Args().First())
 					return nil
 				},
 			},
@@ -27,8 +33,14 @@ func main() {
 				Name:    "search",
 				Usage:   "Search for a GitHub repo then browse the selected repo's releases and assets. [Ex: stew search ripgrep]",
 				Aliases: []string{"s"},
+				Flags: []cli.Flag{
+					&cli.BoolFlag{
+						Name:  "show-all-assets",
+						Usage: "Show all available assets instead of auto-detecting based on OS/Arch",
+					},
+				},
 				Action: func(c *cli.Context) error {
-					cmd.Search(c.Args())
+					cmd.Search(c.Bool("show-all-assets"), c.Args())
 					return nil
 				},
 			},
@@ -50,9 +62,13 @@ func main() {
 						Name:  "all",
 						Usage: "Upgrade all binaries",
 					},
+					&cli.BoolFlag{
+						Name:  "show-all-assets",
+						Usage: "Show all available assets instead of auto-detecting based on OS/Arch (not applicable with --all)",
+					},
 				},
 				Action: func(c *cli.Context) error {
-					cmd.Upgrade(c.Bool("all"), c.Args().First())
+					cmd.Upgrade(c.Bool("all"), c.Bool("show-all-assets"), c.Args().First())
 					return nil
 				},
 			},


### PR DESCRIPTION
Improvements to manual selection
- if manual selection is because of too many results after filtering, only show filtered list
- add --show-all-assets to override (including when automatic would've chosen a single entry)
- add preference for gnu before musl (override with --show-all-assets)

Built using oh-my-pi using GLM-4.7