### PR TITLE
fix: recreate tmp dir before each package upgrade

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -49,6 +49,14 @@ func upgradeOne(binaryName, userOS, userArch string, lockFile stew.LockFile, sys
 	sp := constants.LoadingSpinner
 	stewPkgPath := systemInfo.StewPkgPath
 	stewLockFilePath := systemInfo.StewLockFilePath
+	stewTmpPath := systemInfo.StewTmpPath
+
+	if err := os.RemoveAll(stewTmpPath); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(stewTmpPath, 0755); err != nil {
+		return err
+	}
 
 	indexInLockFile, binaryFoundInLockFile := stew.FindBinaryInLockFile(lockFile, binaryName)
 	if !binaryFoundInLockFile {

--- a/lib/util.go
+++ b/lib/util.go
@@ -305,6 +305,9 @@ func extractBinary(downloadedFilePath, tmpExtractionPath, desiredBinaryRename st
 // InstallBinary will extract the binary and copy it to the ~/.stew/bin path
 func InstallBinary(downloadedFilePath string, repo string, systemInfo SystemInfo, lockFile *LockFile, overwriteFromUpgrade bool, desiredBinaryRename, expectedBinaryHash string) (string, string, error) {
 	tmpExtractionPath, stewPkgPath, binaryInstallPath := systemInfo.StewTmpPath, systemInfo.StewPkgPath, systemInfo.StewBinPath
+	if err := os.MkdirAll(tmpExtractionPath, 0755); err != nil {
+		return "", "", err
+	}
 	if err := extractBinary(downloadedFilePath, tmpExtractionPath, desiredBinaryRename); err != nil {
 		return "", "", err
 	}


### PR DESCRIPTION
## Problem

`stew upgrade --all` fails on packages after the first successful upgrade with:

```
open /home/user/.local/share/stew/tmp/<binary>: no such file or directory
```

This is especially common when the selected asset is a raw binary (not an archive), as seen with tools like `mise`.

## Root Cause

`Upgrade()` creates the tmp directory once at startup (`cmd/upgrade.go:31-34`). Each call to `InstallBinary()` deletes it on completion (`lib/util.go:331-334`). In `upgrade --all`, the loop in `upgradeAll()` calls `upgradeOne()` per package, but `upgradeOne()` never recreates tmp. After the first package installs successfully, tmp is gone and subsequent packages fail.

This is especially visible with non-archive assets (e.g. `mise-v2026.6.1-linux-x64`) because `extractBinary()` tries to `copyFile` into the missing tmp directory, whereas `archiver.Unarchive()` for archives happens to create the directory itself.

## Fix

Two changes:

1. **`cmd/upgrade.go`** — `upgradeOne()` now removes and recreates `StewTmpPath` before each package install, matching the pattern already used in `installOne()` (`cmd/install.go:62-67`) and `Browse()` (`cmd/browse.go:34-37`).

2. **`lib/util.go`** — Defensive `os.MkdirAll(tmpExtractionPath, 0755)` at the top of `InstallBinary()` so the tmp dir is guaranteed to exist regardless of caller behavior.